### PR TITLE
TestRunner refactor round 2, keep decoupling and build test lifecycle: buildDeviceTestTask -> setUp -> run -> tearDown

### DIFF
--- a/agent/doc/UML/logger_file_design.puml
+++ b/agent/doc/UML/logger_file_design.puml
@@ -13,3 +13,9 @@ end note
 
 DeviceTestTaskLogger -u-|> DeviceLogger
 @enduml
+
+@startuml loggers
+EachTestDevice *--> DeviceLogger
+EachTestTaskOnEachTargetDevice *--> TaskOnDeviceLogger
+EachTestTaskOnEachTargetDevice *--> LogcatLogger
+@enduml

--- a/agent/doc/UML/test_runner_design.puml
+++ b/agent/doc/UML/test_runner_design.puml
@@ -75,7 +75,7 @@ deactivate TaskCompletion
     "maxStepCount": "",
     "deviceTestCount": "",
     "testTimeOutSec": "",
-    "deviceSetupActions":[{
+    "deviceSetUpActions":[{
             "action":"setProperty",
             "args": ["log.tag.WelcomeScreen","Verbose"]
         },
@@ -88,20 +88,12 @@ deactivate TaskCompletion
             "args": ["com.android.launcher3.DefaultLauncherApp"]
         }
     ],
-    "deviceTeardownActions":[{
+    "deviceTearDownActions":[{
             "action":"setProperty",
-            "args": ["log.tag.WelcomeScreen","Verbose"]
-        },
-        {
-            "action":"setProperty",
-            "args": ["log.tag.WelcomeScreen","Verbose"]
-        },
-        {
-            "action":"setLauncherAsDefault",
-            "args": ["com.android.launcher3.DefaultLauncherApp"]
+            "args": ["log.tag.WelcomeScreen","-"]
         }
     ],
-    "instrumentationArgs": {
+    "testRunArgs": {
         "enableScreenRecord": false,
         "testInterval": 5000,
         "runtimeUpLimit": 1,
@@ -130,12 +122,6 @@ interface TestRunnerListener {
 }
 
 Runner *--> TestRunnerListener
-@enduml
-
-@startuml loggers
-EachTestDevice *--> DeviceLogger
-EachTestTaskOnEachTargetDevice *--> TaskOnDeviceLogger
-EachTestTaskOnEachTargetDevice *--> LogcatLogger
 @enduml
 
 @startuml test_objects

--- a/agent/doc/UML/test_runner_design.puml
+++ b/agent/doc/UML/test_runner_design.puml
@@ -1,10 +1,9 @@
 @startuml test_runners_classes
 abstract class TestRunner {
-    #getDeviceTask(...)
-    +setupTestDir(TestTask)
-    +runTest(TestTaskSpec)
-    +initDevice(...)
-    #afterTest(...)
+    #buildDeviceTestTask(...)
+    #setUp(TestTask)
+    #run(TestTaskSpec)
+    #tearDown(...)
 }
 interface TestRunningCallback
 
@@ -22,64 +21,6 @@ AppiumCrossRunner --|> AppiumRunner
 @enduml
 
 @startuml running_sequence
-AgentWebSocketClientService -> DeviceControlService :runTestTask
-activate DeviceControlService
-
-DeviceControlService -> TestRunner: runTest
-activate TestRunner
-
-TestRunner -> TestRunner: chooseDevices
-TestRunner -> TestTask: convertToTestTask(static)
-TestRunner -> RunningControlService: runForAllDeviceAsync
-activate RunningControlService
-
-RunningControlService --> TestThreadPool.Executor: execute
-activate TestThreadPool.Executor
-
-RunningControlService -> TestRunner
-deactivate RunningControlService
-
-TestRunner -> DeviceControlService
-deactivate TestRunner
-
-DeviceControlService -> AgentWebSocketClientService
-deactivate DeviceControlService
-
-participant DeviceTask
-note over DeviceTask #aqua
-DeviceTask
-seems
-extra.
-end note
-
-TestThreadPool.Executor -> DeviceTask: doTask
-activate DeviceTask
-
-DeviceTask -> RunnerImpl : runTestImpl
-activate RunnerImpl #FFBBFF
-note right: each runner implements this logic
-RunnerImpl -> DeviceTask
-deactivate RunnerImpl
-
-
-DeviceTask -> TestThreadPool.Executor
-deactivate DeviceTask
-
-TestThreadPool.Executor -> TaskCompletion: onComplete
-activate TaskCompletion
-
-TaskCompletion -> TestRunningCallback: onAllComplete
-activate TestRunningCallback
-
-TestRunningCallback -> TaskCompletion
-deactivate TestRunningCallback
-
-TaskCompletion -> TestThreadPool.Executor
-deactivate TaskCompletion
-
-@enduml
-
-@startuml running_sequence
 AgentWebSocketClientService -> TestTaskEngineService :runTestTask(TestTaskSpec)
 activate TestTaskEngineService
 TestTaskEngineService -> TestTaskEngineService: chooseDevices
@@ -90,36 +31,22 @@ activate DeviceTaskControlExecutor
 
 
 
-
-
-
-
 DeviceTaskControlExecutor --> TestThreadPool.Executor: execute
 activate TestThreadPool.Executor
 
-DeviceTaskControlExecutor -> TestRunner
-
+DeviceTaskControlExecutor -> TestTaskEngineService
 deactivate DeviceTaskControlExecutor
-activate TestRunner
-TestRunner -> TestTaskEngineService
-deactivate TestRunner
 
 TestTaskEngineService -> AgentWebSocketClientService
 deactivate TestTaskEngineService
 
 participant DeviceTask
-DeviceTask -> TestRunner: runTest
-
 TestThreadPool.Executor -> DeviceTask: doTask
 activate DeviceTask
-
-DeviceTask -> RunnerImpl : runTestImpl
-activate RunnerImpl #FFBBFF
-note right: each runner implements this logic
-RunnerImpl -> DeviceTask
-deactivate RunnerImpl
-
-
+DeviceTask -> TestRunner: runTestOnDevice
+activate TestRunner
+TestRunner -> DeviceTask
+deactivate TestRunner
 DeviceTask -> TestThreadPool.Executor
 deactivate DeviceTask
 
@@ -208,6 +135,7 @@ Runner *--> TestRunnerListener
 @startuml loggers
 EachTestDevice *--> DeviceLogger
 EachTestTaskOnEachTargetDevice *--> TaskOnDeviceLogger
+EachTestTaskOnEachTargetDevice *--> LogcatLogger
 @enduml
 
 @startuml test_objects

--- a/agent/doc/UML/test_runner_design.puml
+++ b/agent/doc/UML/test_runner_design.puml
@@ -1,7 +1,6 @@
 @startuml test_runners_classes
 abstract class TestRunner {
     #getDeviceTask(...)
-    #chooseDevices(TestTaskSpec)
     +setupTestDir(TestTask)
     +runTest(TestTaskSpec)
     +initDevice(...)
@@ -52,6 +51,64 @@ DeviceTask
 seems
 extra.
 end note
+
+TestThreadPool.Executor -> DeviceTask: doTask
+activate DeviceTask
+
+DeviceTask -> RunnerImpl : runTestImpl
+activate RunnerImpl #FFBBFF
+note right: each runner implements this logic
+RunnerImpl -> DeviceTask
+deactivate RunnerImpl
+
+
+DeviceTask -> TestThreadPool.Executor
+deactivate DeviceTask
+
+TestThreadPool.Executor -> TaskCompletion: onComplete
+activate TaskCompletion
+
+TaskCompletion -> TestRunningCallback: onAllComplete
+activate TestRunningCallback
+
+TestRunningCallback -> TaskCompletion
+deactivate TestRunningCallback
+
+TaskCompletion -> TestThreadPool.Executor
+deactivate TaskCompletion
+
+@enduml
+
+@startuml running_sequence
+AgentWebSocketClientService -> TestTaskEngineService :runTestTask(TestTaskSpec)
+activate TestTaskEngineService
+TestTaskEngineService -> TestTaskEngineService: chooseDevices
+TestTaskEngineService -> TestTask: convertToTestTask(static)
+
+TestTaskEngineService -> DeviceTaskControlExecutor: runForAllDeviceAsync
+activate DeviceTaskControlExecutor
+
+
+
+
+
+
+
+DeviceTaskControlExecutor --> TestThreadPool.Executor: execute
+activate TestThreadPool.Executor
+
+DeviceTaskControlExecutor -> TestRunner
+
+deactivate DeviceTaskControlExecutor
+activate TestRunner
+TestRunner -> TestTaskEngineService
+deactivate TestRunner
+
+TestTaskEngineService -> AgentWebSocketClientService
+deactivate TestTaskEngineService
+
+participant DeviceTask
+DeviceTask -> TestRunner: runTest
 
 TestThreadPool.Executor -> DeviceTask: doTask
 activate DeviceTask
@@ -175,8 +232,12 @@ entity (TestUnitResult)
 entity (AgentDeviceManager)
 entity (DeviceManager)
 entity (TestDevice)
+entity (DevicePair)
 
 AgentDeviceManager *--> DeviceManager
+DeviceManager *--> TestDevice
+
+DevicePair *-u-> TestDevice
 
 TestTask ... TestDevice: is running on
 

--- a/agent/src/main/java/com/microsoft/hydralab/agent/config/TestRunnerConfig.java
+++ b/agent/src/main/java/com/microsoft/hydralab/agent/config/TestRunnerConfig.java
@@ -1,0 +1,70 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+package com.microsoft.hydralab.agent.config;
+
+import com.microsoft.hydralab.agent.runner.appium.AppiumCrossRunner;
+import com.microsoft.hydralab.agent.runner.appium.AppiumRunner;
+import com.microsoft.hydralab.agent.runner.espresso.EspressoRunner;
+import com.microsoft.hydralab.agent.runner.monkey.AdbMonkeyRunner;
+import com.microsoft.hydralab.agent.runner.monkey.AppiumMonkeyRunner;
+import com.microsoft.hydralab.agent.runner.smart.SmartRunner;
+import com.microsoft.hydralab.agent.runner.smart.SmartTestUtil;
+import com.microsoft.hydralab.agent.runner.t2c.T2CRunner;
+import com.microsoft.hydralab.agent.service.TestTaskEngineService;
+import com.microsoft.hydralab.common.entity.common.TestTask;
+import com.microsoft.hydralab.common.management.DeviceManager;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.Map;
+
+@Configuration
+public class TestRunnerConfig {
+    @Value("${app.registry.name}")
+    String agentName;
+    public static Map<String, String> TestRunnerMap = Map.of(
+            TestTask.TestRunningType.INSTRUMENTATION, "espressoRunner",
+            TestTask.TestRunningType.APPIUM, "appiumRunner",
+            TestTask.TestRunningType.APPIUM_CROSS, "appiumCrossRunner",
+            TestTask.TestRunningType.SMART_TEST, "smartRunner",
+            TestTask.TestRunningType.MONKEY_TEST, "adbMonkeyRunner",
+            TestTask.TestRunningType.APPIUM_MONKEY_TEST, "appiumMonkeyRunner",
+            TestTask.TestRunningType.T2C_JSON_TEST, "t2cRunner"
+    );
+
+    @Bean
+    public EspressoRunner espressoRunner(DeviceManager deviceManager, TestTaskEngineService testTaskEngineService) {
+        return new EspressoRunner(deviceManager, testTaskEngineService);
+    }
+
+    @Bean
+    public AdbMonkeyRunner adbMonkeyRunner(DeviceManager deviceManager, TestTaskEngineService testTaskEngineService) {
+        return new AdbMonkeyRunner(deviceManager, testTaskEngineService);
+    }
+
+    @Bean
+    public AppiumMonkeyRunner appiumMonkeyRunner(DeviceManager deviceManager, TestTaskEngineService testTaskEngineService) {
+        return new AppiumMonkeyRunner(deviceManager, testTaskEngineService);
+    }
+
+    @Bean
+    public AppiumRunner appiumRunner(DeviceManager deviceManager, TestTaskEngineService testTaskEngineService) {
+        return new AppiumRunner(deviceManager, testTaskEngineService);
+    }
+
+    @Bean
+    public AppiumCrossRunner appiumCrossRunner(DeviceManager deviceManager, TestTaskEngineService testTaskEngineService) {
+        return new AppiumCrossRunner(deviceManager, testTaskEngineService, agentName);
+    }
+
+    @Bean
+    public SmartRunner smartRunner(DeviceManager deviceManager, TestTaskEngineService testTaskEngineService, SmartTestUtil smartTestUtil) {
+        return new SmartRunner(deviceManager, testTaskEngineService, smartTestUtil);
+    }
+
+    @Bean
+    public T2CRunner t2cRunner(DeviceManager deviceManager, TestTaskEngineService testTaskEngineService) {
+        return new T2CRunner(deviceManager, testTaskEngineService, agentName);
+    }
+}

--- a/agent/src/main/java/com/microsoft/hydralab/agent/runner/TestRunner.java
+++ b/agent/src/main/java/com/microsoft/hydralab/agent/runner/TestRunner.java
@@ -12,51 +12,108 @@ import com.microsoft.hydralab.common.util.LogUtils;
 import com.microsoft.hydralab.common.util.ThreadUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.stereotype.Service;
 
-import javax.annotation.Resource;
 import java.io.File;
 import java.util.Date;
 
-@Service
 public abstract class TestRunner {
-    protected Logger log = LoggerFactory.getLogger(DeviceManager.class);
-    @Resource
-    protected DeviceManager deviceManager;
-    @Resource
-    XmlBuilder xmlBuilder;
-    @Resource(name = "TestTaskEngineService")
-    protected TestTaskRunCallback testTaskRunCallback;
+    protected final Logger log = LoggerFactory.getLogger(DeviceManager.class);
+    protected final DeviceManager deviceManager;
+    protected final TestTaskRunCallback testTaskRunCallback;
+    protected final XmlBuilder xmlBuilder = new XmlBuilder();
 
-    public abstract void runTestOnDevice(TestTask testTask, DeviceInfo deviceInfo, Logger logger);
+    public TestRunner(DeviceManager deviceManager, TestTaskRunCallback testTaskRunCallback) {
+        this.deviceManager = deviceManager;
+        this.testTaskRunCallback = testTaskRunCallback;
+    }
 
+    public void runTestOnDevice(TestTask testTask, DeviceInfo deviceInfo, Logger logger) throws Exception {
+        checkTestTaskCancel(testTask);
+        logger.info("Start running tests {}, timeout {}s", testTask.getTestSuite(), testTask.getTimeOutSecond());
+
+        DeviceTestTask deviceTestTask = buildDeviceTestTask(deviceInfo, testTask, logger);
+        checkTestTaskCancel(testTask);
+
+        setUp(deviceInfo, testTask, deviceTestTask);
+        checkTestTaskCancel(testTask);
+
+        try {
+            run(deviceInfo, testTask, deviceTestTask);
+        } catch (Exception e) {
+            deviceTestTask.getLogger().info(deviceInfo.getSerialNum() + ": " + e.getMessage(), e);
+            String errorStr = e.getClass().getName() + ": " + e.getMessage();
+            if (errorStr.length() > 255) {
+                errorStr = errorStr.substring(0, 254);
+            }
+            deviceTestTask.setErrorInProcess(errorStr);
+        } finally {
+            tearDown(deviceInfo, testTask, deviceTestTask);
+        }
+    }
 
     protected void checkTestTaskCancel(TestTask testTask) {
         Assert.isFalse(testTask.isCanceled(), "Task {} is canceled", testTask.getId());
     }
 
-    public void initDevice(DeviceInfo deviceInfo, TestTask testTask, Logger reportLogger) throws Exception {
+    protected DeviceTestTask buildDeviceTestTask(DeviceInfo deviceInfo, TestTask testTask, Logger parentLogger) {
+        DeviceTestTask deviceTestTask = new DeviceTestTask(deviceInfo.getSerialNum(), deviceInfo.getName(), testTask.getId());
+        File deviceTestResultFolder = new File(testTask.getResourceDir(), deviceInfo.getSerialNum());
+        parentLogger.info("DeviceTestResultFolder {}", deviceTestResultFolder);
+        if (!deviceTestResultFolder.exists()) {
+            if (!deviceTestResultFolder.mkdirs()) {
+                throw new RuntimeException("deviceTestResultFolder.mkdirs() failed: " + deviceTestResultFolder);
+            }
+        }
+        deviceTestTask.setDeviceTestResultFolder(deviceTestResultFolder);
+        Logger loggerForDeviceTestTask = createLoggerForDeviceTestTask(deviceTestTask, testTask.getTestSuite(), parentLogger);
+        deviceTestTask.setLogger(loggerForDeviceTestTask);
+        testTask.addTestedDeviceResult(deviceTestTask);
+        return deviceTestTask;
+    }
+
+    protected void setUp(DeviceInfo deviceInfo, TestTask testTask, DeviceTestTask deviceTestTask) throws Exception {
         deviceInfo.killAll();
         // this key will be used to recover device status when lost the connection between agent and master
         deviceInfo.addCurrentTask(testTask);
 
         /* set up device */
-        reportLogger.info("Start setup device");
-        deviceManager.testDeviceSetup(deviceInfo, reportLogger);
-        deviceManager.wakeUpDevice(deviceInfo, reportLogger);
+        deviceTestTask.getLogger().info("Start setup device");
+        deviceManager.testDeviceSetup(deviceInfo, deviceTestTask.getLogger());
+        deviceManager.wakeUpDevice(deviceInfo, deviceTestTask.getLogger());
         ThreadUtils.safeSleep(1000);
         checkTestTaskCancel(testTask);
-        reInstallApp(deviceInfo, testTask, reportLogger);
+        reInstallApp(deviceInfo, testTask, deviceTestTask.getLogger());
 
         if (testTask.isThisForMicrosoftLauncher()) {
-            presetForMicrosoftLauncherApp(deviceInfo, testTask, reportLogger);
+            presetForMicrosoftLauncherApp(deviceInfo, testTask, deviceTestTask.getLogger());
         }
 
-        reportLogger.info("Start granting all package needed permissions device");
-        deviceManager.grantAllTaskNeededPermissions(deviceInfo, testTask, reportLogger);
+        deviceTestTask.getLogger().info("Start granting all package needed permissions device");
+        deviceManager.grantAllTaskNeededPermissions(deviceInfo, testTask, deviceTestTask.getLogger());
 
         checkTestTaskCancel(testTask);
-        deviceManager.getScreenShot(deviceInfo, log);
+        deviceManager.getScreenShot(deviceInfo, deviceTestTask.getLogger());
+    }
+
+    protected abstract void run(DeviceInfo deviceInfo, TestTask testTask, DeviceTestTask deviceTestTask) throws Exception;
+
+    protected void tearDown(DeviceInfo deviceInfo, TestTask testTask, DeviceTestTask deviceTestTask) {
+        try {
+            String absoluteReportPath = xmlBuilder.buildTestResultXml(testTask, deviceTestTask);
+            deviceTestTask.setTestXmlReportPath(deviceManager.getTestBaseRelPathInUrl(new File(absoluteReportPath)));
+        } catch (Exception e) {
+            deviceTestTask.getLogger().error("Error in buildTestResultXml", e);
+        }
+        if (testTaskRunCallback != null) {
+            try {
+                testTaskRunCallback.onOneDeviceComplete(testTask, deviceInfo, deviceTestTask.getLogger(), deviceTestTask);
+            } catch (Exception e) {
+                deviceTestTask.getLogger().error("Error in onOneDeviceComplete", e);
+            }
+        }
+        deviceManager.testDeviceUnset(deviceInfo, deviceTestTask.getLogger());
+        deviceTestTask.getLogger().info("Start Close/finish resource");
+        LogUtils.releaseLogger(deviceTestTask.getLogger());
     }
 
     private void presetForMicrosoftLauncherApp(DeviceInfo deviceInfo, TestTask testTask, Logger reportLogger) {
@@ -76,30 +133,8 @@ public abstract class TestRunner {
         ThreadUtils.safeSleep(3000);
     }
 
-    protected void afterTest(DeviceInfo deviceInfo, TestTask testTask, DeviceTestTask deviceTestTask, TestTaskRunCallback testTaskRunCallback, Logger reportLogger) {
-        if (testTaskRunCallback != null) {
-            try {
-                String absoluteReportPath = xmlBuilder.buildTestResultXml(testTask, deviceTestTask);
-                deviceTestTask.setTestXmlReportPath(deviceManager.getTestBaseRelPathInUrl(new File(absoluteReportPath)));
-            } catch (Exception e) {
-                reportLogger.error("Error in buildTestResultXml", e);
-            }
-            try {
-                testTaskRunCallback.onOneDeviceComplete(testTask, deviceInfo, reportLogger, deviceTestTask);
-            } catch (Exception e) {
-                reportLogger.error("Error in onOneDeviceComplete", e);
-            }
-        }
-        deviceManager.testDeviceUnset(deviceInfo, reportLogger);
-        reportLogger.info("Finally: restore state");
-        /* Close/finish resource */
-        if (reportLogger != null) {
-            reportLogger.info("Start Close/finish resource");
-            LogUtils.releaseLogger(reportLogger);
-        }
-    }
 
-    public void reInstallApp(DeviceInfo deviceInfo, TestTask testTask, Logger reportLogger) throws Exception {
+    protected void reInstallApp(DeviceInfo deviceInfo, TestTask testTask, Logger reportLogger) throws Exception {
         if (testTask.getRequireReinstall()) {
             deviceManager.uninstallApp(deviceInfo, testTask.getPkgName(), reportLogger);
             deviceManager.uninstallApp(deviceInfo, testTask.getTestPkgName(), reportLogger);
@@ -127,17 +162,4 @@ public abstract class TestRunner {
         return reportLogger;
     }
 
-    protected DeviceTestTask initDeviceTestTask(DeviceInfo deviceInfo, TestTask testTask, Logger logger) {
-        DeviceTestTask deviceTestTask = new DeviceTestTask(deviceInfo.getSerialNum(), deviceInfo.getName(), testTask.getId());
-        File deviceTestResultFolder = new File(testTask.getResourceDir(), deviceInfo.getSerialNum());
-        logger.info("DeviceTestResultFolder {}", deviceTestResultFolder);
-        if (!deviceTestResultFolder.exists()) {
-            if (!deviceTestResultFolder.mkdirs()) {
-                throw new RuntimeException("deviceTestResultFolder.mkdirs() failed: " + deviceTestResultFolder);
-            }
-        }
-        deviceTestTask.setDeviceTestResultFolder(deviceTestResultFolder);
-        deviceTestTask.setLogger(createLoggerForDeviceTestTask(deviceTestTask, testTask.getTestSuite(), logger));
-        return deviceTestTask;
-    }
 }

--- a/agent/src/main/java/com/microsoft/hydralab/agent/runner/TestRunner.java
+++ b/agent/src/main/java/com/microsoft/hydralab/agent/runner/TestRunner.java
@@ -40,15 +40,19 @@ public abstract class TestRunner {
         try {
             run(deviceInfo, testTask, deviceTestTask);
         } catch (Exception e) {
-            deviceTestTask.getLogger().info(deviceInfo.getSerialNum() + ": " + e.getMessage(), e);
-            String errorStr = e.getClass().getName() + ": " + e.getMessage();
-            if (errorStr.length() > 255) {
-                errorStr = errorStr.substring(0, 254);
-            }
-            deviceTestTask.setErrorInProcess(errorStr);
+            deviceTestTask.getLogger().error(deviceInfo.getSerialNum() + ": " + e.getMessage(), e);
+            saveErrorSummary(deviceTestTask, e);
         } finally {
             tearDown(deviceInfo, testTask, deviceTestTask);
         }
+    }
+
+    private static void saveErrorSummary(DeviceTestTask deviceTestTask, Exception e) {
+        String errorStr = e.getClass().getName() + ": " + e.getMessage();
+        if (errorStr.length() > 255) {
+            errorStr = errorStr.substring(0, 254);
+        }
+        deviceTestTask.setErrorInProcess(errorStr);
     }
 
     protected void checkTestTaskCancel(TestTask testTask) {

--- a/agent/src/main/java/com/microsoft/hydralab/agent/runner/TestRunner.java
+++ b/agent/src/main/java/com/microsoft/hydralab/agent/runner/TestRunner.java
@@ -155,6 +155,9 @@ public abstract class TestRunner {
     }
 
     protected void reInstallTestApp(DeviceInfo deviceInfo, TestTask testTask, Logger reportLogger) throws Exception {
+        if(!shouldInstallTestPackageAsApp()){
+            return;
+        }
         if (testTask.getTestAppFile() == null) {
             return;
         }
@@ -169,6 +172,10 @@ public abstract class TestRunner {
         }
         checkTestTaskCancel(testTask);
         deviceManager.installApp(deviceInfo, testTask.getTestAppFile().getAbsolutePath(), reportLogger);
+    }
+
+    protected boolean shouldInstallTestPackageAsApp() {
+        return false;
     }
 
     private Logger createLoggerForDeviceTestTask(DeviceTestTask deviceTestTask, String loggerNamePrefix, Logger parentLogger) {

--- a/agent/src/main/java/com/microsoft/hydralab/agent/runner/XmlBuilder.java
+++ b/agent/src/main/java/com/microsoft/hydralab/agent/runner/XmlBuilder.java
@@ -6,7 +6,6 @@ import com.microsoft.hydralab.common.entity.common.AndroidTestUnit;
 import com.microsoft.hydralab.common.entity.common.DeviceTestTask;
 import com.microsoft.hydralab.common.entity.common.TestTask;
 import com.microsoft.hydralab.common.util.DateUtil;
-import org.springframework.stereotype.Service;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
@@ -24,7 +23,6 @@ import java.util.Date;
  * @author zhoule
  * @date 10/31/2022
  */
-@Service
 public class XmlBuilder {
     private static final String TEST_RESULT_FILE_SUFFIX = ".xml";
     private static final String TEST_RESULT_FILE_PREFIX = "hydra_result_";

--- a/agent/src/main/java/com/microsoft/hydralab/agent/runner/appium/AppiumCrossRunner.java
+++ b/agent/src/main/java/com/microsoft/hydralab/agent/runner/appium/AppiumCrossRunner.java
@@ -18,7 +18,7 @@ public class AppiumCrossRunner extends AppiumRunner {
     }
 
     @Override
-    public DeviceTestTask buildDeviceTestTask(DeviceInfo deviceInfo, TestTask testTask, Logger parentLogger) {
+    protected DeviceTestTask buildDeviceTestTask(DeviceInfo deviceInfo, TestTask testTask, Logger parentLogger) {
         DeviceTestTask deviceTestTask = super.buildDeviceTestTask(deviceInfo, testTask, parentLogger);
         String deviceName = System.getProperties().getProperty("os.name") + "-" + agentName + "-" + deviceInfo.getName();
         deviceTestTask.setDeviceName(deviceName);

--- a/agent/src/main/java/com/microsoft/hydralab/agent/runner/appium/AppiumCrossRunner.java
+++ b/agent/src/main/java/com/microsoft/hydralab/agent/runner/appium/AppiumCrossRunner.java
@@ -2,25 +2,24 @@
 // Licensed under the MIT License.
 package com.microsoft.hydralab.agent.runner.appium;
 
-import com.microsoft.hydralab.common.entity.center.TestTaskSpec;
+import com.microsoft.hydralab.agent.runner.TestTaskRunCallback;
 import com.microsoft.hydralab.common.entity.common.DeviceInfo;
 import com.microsoft.hydralab.common.entity.common.DeviceTestTask;
 import com.microsoft.hydralab.common.entity.common.TestTask;
+import com.microsoft.hydralab.common.management.DeviceManager;
 import org.slf4j.Logger;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.stereotype.Service;
-import org.springframework.util.Assert;
 
-import java.util.Set;
-
-@Service("appiumCrossRunner")
 public class AppiumCrossRunner extends AppiumRunner {
-    @Value("${app.registry.name}")
     String agentName;
 
+    public AppiumCrossRunner(DeviceManager deviceManager, TestTaskRunCallback testTaskRunCallback, String agentName) {
+        super(deviceManager, testTaskRunCallback);
+        this.agentName = agentName;
+    }
+
     @Override
-    public DeviceTestTask initDeviceTestTask(DeviceInfo deviceInfo, TestTask testTask, Logger logger) {
-        DeviceTestTask deviceTestTask = super.initDeviceTestTask(deviceInfo, testTask, logger);
+    public DeviceTestTask buildDeviceTestTask(DeviceInfo deviceInfo, TestTask testTask, Logger parentLogger) {
+        DeviceTestTask deviceTestTask = super.buildDeviceTestTask(deviceInfo, testTask, parentLogger);
         String deviceName = System.getProperties().getProperty("os.name") + "-" + agentName + "-" + deviceInfo.getName();
         deviceTestTask.setDeviceName(deviceName);
         return deviceTestTask;

--- a/agent/src/main/java/com/microsoft/hydralab/agent/runner/appium/AppiumRunner.java
+++ b/agent/src/main/java/com/microsoft/hydralab/agent/runner/appium/AppiumRunner.java
@@ -152,16 +152,4 @@ public class AppiumRunner extends TestRunner {
         }
     }
 
-    @Override
-    protected void reInstallApp(DeviceInfo deviceInfo, TestTask testTask, Logger reportLogger) throws Exception {
-        if (testTask.getRequireReinstall() || deviceManager instanceof IOSDeviceManager) {
-            deviceManager.uninstallApp(deviceInfo, testTask.getPkgName(), reportLogger);
-            ThreadUtils.safeSleep(1000);
-        } else if (testTask.getRequireClearData()) {
-            deviceManager.resetPackage(deviceInfo, testTask.getPkgName(), reportLogger);
-        }
-        checkTestTaskCancel(testTask);
-
-        deviceManager.installApp(deviceInfo, testTask.getAppFile().getAbsolutePath(), reportLogger);
-    }
 }

--- a/agent/src/main/java/com/microsoft/hydralab/agent/runner/appium/AppiumRunner.java
+++ b/agent/src/main/java/com/microsoft/hydralab/agent/runner/appium/AppiumRunner.java
@@ -9,6 +9,7 @@ import com.microsoft.hydralab.appium.ThreadParam;
 import com.microsoft.hydralab.common.entity.common.DeviceInfo;
 import com.microsoft.hydralab.common.entity.common.DeviceTestTask;
 import com.microsoft.hydralab.common.entity.common.TestTask;
+import com.microsoft.hydralab.common.management.DeviceManager;
 import com.microsoft.hydralab.common.management.impl.IOSDeviceManager;
 import com.microsoft.hydralab.common.util.IOSUtils;
 import com.microsoft.hydralab.common.util.LogUtils;
@@ -21,7 +22,6 @@ import org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder;
 import org.junit.platform.launcher.core.LauncherFactory;
 import org.junit.runner.JUnitCore;
 import org.slf4j.Logger;
-import org.springframework.stereotype.Service;
 
 import java.io.File;
 import java.net.MalformedURLException;
@@ -32,59 +32,31 @@ import java.util.Map;
 
 import static org.junit.platform.engine.discovery.DiscoverySelectors.selectClass;
 
-@Service("appiumRunner")
 public class AppiumRunner extends TestRunner {
 
-    @Override
-    public void runTestOnDevice(TestTask testTask, DeviceInfo deviceInfo, Logger logger) {
-        runAppiumTest(testTask.getTestAppFile(), testTask.getTestSuite(), deviceInfo, testTask, testTaskRunCallback, logger);
+    public AppiumRunner(DeviceManager deviceManager, TestTaskRunCallback testTaskRunCallback) {
+        super(deviceManager, testTaskRunCallback);
     }
 
-    public void runAppiumTest(File appiumJarFile, String appiumCommand, DeviceInfo deviceInfo,
-                              TestTask testTask,
-                              TestTaskRunCallback testTaskRunCallback, Logger logger) {
-        checkTestTaskCancel(testTask);
-        logger.info("Start running tests {}, timeout {}s", testTask.getTestSuite(), testTask.getTimeOutSecond());
+    @Override
+    protected void run(DeviceInfo deviceInfo, TestTask testTask, DeviceTestTask deviceTestTask) throws Exception {
 
-        DeviceTestTask deviceTestTask = initDeviceTestTask(deviceInfo, testTask, logger);
-        File deviceTestResultFolder = deviceTestTask.getDeviceTestResultFolder();
-        testTask.addTestedDeviceResult(deviceTestTask);
-        checkTestTaskCancel(testTask);
-
-        Logger reportLogger = null;
-
+        Logger reportLogger = deviceTestTask.getLogger();
         try {
-            reportLogger = deviceTestTask.getLogger();
-            initDevice(deviceInfo, testTask, reportLogger);
-
-            File gifFile = runAndGetGif(appiumJarFile, appiumCommand, deviceInfo, testTask, deviceTestTask, deviceTestResultFolder, reportLogger);
+            File gifFile = runAndGetGif(testTask.getTestAppFile(), testTask.getTestSuite(), deviceInfo, testTask, deviceTestTask, deviceTestTask.getDeviceTestResultFolder(), reportLogger);
             if (gifFile != null && gifFile.exists() && gifFile.length() > 0) {
                 deviceTestTask.setTestGifPath(deviceManager.getTestBaseRelPathInUrl(gifFile));
             }
-
-        } catch (Exception e) {
-            e.printStackTrace();
-            if (reportLogger != null) {
-                reportLogger.info(deviceInfo.getSerialNum() + ": " + e.getMessage(), e);
-            } else {
-                logger.info(deviceInfo.getSerialNum() + ": " + e.getMessage(), e);
-            }
-            String errorStr = e.getClass().getName() + ": " + e.getMessage();
-            if (errorStr.length() > 255) {
-                errorStr = errorStr.substring(0, 254);
-            }
-            deviceTestTask.setErrorInProcess(errorStr);
         } finally {
             //clear config
             ThreadParam.clean();
-            afterTest(deviceInfo, testTask, deviceTestTask, testTaskRunCallback, reportLogger);
         }
     }
 
     @Override
-    protected void afterTest(DeviceInfo deviceInfo, TestTask testTask, DeviceTestTask deviceTestTask, TestTaskRunCallback testTaskRunCallback, Logger reportLogger) {
-        quitAppiumDrivers(deviceInfo, testTask, reportLogger);
-        super.afterTest(deviceInfo, testTask, deviceTestTask, testTaskRunCallback, reportLogger);
+    protected void tearDown(DeviceInfo deviceInfo, TestTask testTask, DeviceTestTask deviceTestTask) {
+        quitAppiumDrivers(deviceInfo, testTask, deviceTestTask.getLogger());
+        super.tearDown(deviceInfo, testTask, deviceTestTask);
     }
 
     protected void quitAppiumDrivers(DeviceInfo deviceInfo, TestTask testTask, Logger reportLogger) {
@@ -181,7 +153,7 @@ public class AppiumRunner extends TestRunner {
     }
 
     @Override
-    public void reInstallApp(DeviceInfo deviceInfo, TestTask testTask, Logger reportLogger) throws Exception {
+    protected void reInstallApp(DeviceInfo deviceInfo, TestTask testTask, Logger reportLogger) throws Exception {
         if (testTask.getRequireReinstall() || deviceManager instanceof IOSDeviceManager) {
             deviceManager.uninstallApp(deviceInfo, testTask.getPkgName(), reportLogger);
             ThreadUtils.safeSleep(1000);

--- a/agent/src/main/java/com/microsoft/hydralab/agent/runner/espresso/EspressoRunner.java
+++ b/agent/src/main/java/com/microsoft/hydralab/agent/runner/espresso/EspressoRunner.java
@@ -70,6 +70,10 @@ public class EspressoRunner extends TestRunner {
         }
     }
 
+    @Override
+    protected boolean shouldInstallTestPackageAsApp() {
+        return true;
+    }
 
     public String startInstrument(DeviceInfo deviceInfo, String scope, String suiteName, String testPkgName, String testRunnerName, Logger logger, IShellOutputReceiver receiver,
                                   int testTimeOutSec, Map<String, String> instrumentationArgs) {

--- a/agent/src/main/java/com/microsoft/hydralab/agent/runner/espresso/EspressoRunner.java
+++ b/agent/src/main/java/com/microsoft/hydralab/agent/runner/espresso/EspressoRunner.java
@@ -21,7 +21,7 @@ import java.util.Collections;
 import java.util.Map;
 
 public class EspressoRunner extends TestRunner {
-    ADBOperateUtil adbOperateUtil = new ADBOperateUtil();
+    final ADBOperateUtil adbOperateUtil = new ADBOperateUtil();
 
     public EspressoRunner(DeviceManager deviceManager, TestTaskRunCallback testTaskRunCallback) {
         super(deviceManager, testTaskRunCallback);

--- a/agent/src/main/java/com/microsoft/hydralab/agent/runner/espresso/EspressoTestInfoProcessorListener.java
+++ b/agent/src/main/java/com/microsoft/hydralab/agent/runner/espresso/EspressoTestInfoProcessorListener.java
@@ -6,7 +6,6 @@ import cn.hutool.core.img.ImgUtil;
 import cn.hutool.core.img.gif.AnimatedGifEncoder;
 import cn.hutool.core.lang.Assert;
 import com.android.ddmlib.testrunner.TestIdentifier;
-import com.microsoft.hydralab.common.util.Const;
 import com.microsoft.hydralab.common.entity.common.AndroidTestUnit;
 import com.microsoft.hydralab.common.entity.common.DeviceInfo;
 import com.microsoft.hydralab.common.entity.common.DeviceTestTask;
@@ -14,16 +13,19 @@ import com.microsoft.hydralab.common.logger.LogCollector;
 import com.microsoft.hydralab.common.management.DeviceManager;
 import com.microsoft.hydralab.common.screen.ScreenRecorder;
 import com.microsoft.hydralab.common.util.ADBOperateUtil;
+import com.microsoft.hydralab.common.util.Const;
 import org.slf4j.Logger;
 
 import javax.imageio.ImageIO;
 import java.io.File;
 import java.io.IOException;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
-public class EspressoListener extends XmlTestRunListener {
+public class EspressoTestInfoProcessorListener extends XmlTestRunListener {
 
     private final DeviceInfo deviceInfo;
     private final DeviceTestTask deviceTestResult;
@@ -43,15 +45,21 @@ public class EspressoListener extends XmlTestRunListener {
     private int pid;
     private int addedFrameCount;
 
-    public EspressoListener(DeviceManager deviceManager, ADBOperateUtil adbOperateUtil, DeviceInfo deviceInfo, DeviceTestTask deviceTestResult, String pkgName, Logger logger) {
+    public EspressoTestInfoProcessorListener(DeviceManager deviceManager, ADBOperateUtil adbOperateUtil, DeviceInfo deviceInfo, DeviceTestTask deviceTestResult, String pkgName) {
         this.deviceManager = deviceManager;
         this.adbOperateUtil = adbOperateUtil;
         this.deviceInfo = deviceInfo;
         this.deviceTestResult = deviceTestResult;
-        this.logger = logger;
+        this.logger = deviceTestResult.getLogger();
         this.pkgName = pkgName;
         adbLogcatCollector = deviceManager.getLogCollector(deviceInfo, pkgName, deviceTestResult, logger);
         adbDeviceScreenRecorder = deviceManager.getScreenRecorder(deviceInfo, deviceTestResult.getDeviceTestResultFolder(), logger);
+        setReportDir(deviceTestResult.getDeviceTestResultFolder());
+        try {
+            setHostName(InetAddress.getLocalHost().getHostName());
+        } catch (UnknownHostException ex) {
+            logger.error(ex.getMessage(), ex);
+        }
     }
 
     public File getGifFile() {

--- a/agent/src/main/java/com/microsoft/hydralab/agent/runner/monkey/AdbMonkeyRunner.java
+++ b/agent/src/main/java/com/microsoft/hydralab/agent/runner/monkey/AdbMonkeyRunner.java
@@ -193,16 +193,4 @@ public class AdbMonkeyRunner extends TestRunner {
         logCollector.stopAndAnalyse();
     }
 
-    @Override
-    protected void reInstallApp(DeviceInfo deviceInfo, TestTask testTask, Logger reportLogger) throws Exception {
-        if (testTask.getRequireReinstall() || deviceManager instanceof IOSDeviceManager) {
-            deviceManager.uninstallApp(deviceInfo, testTask.getPkgName(), reportLogger);
-            ThreadUtils.safeSleep(1000);
-        } else if (testTask.getRequireClearData()) {
-            deviceManager.resetPackage(deviceInfo, testTask.getPkgName(), reportLogger);
-        }
-        checkTestTaskCancel(testTask);
-
-        deviceManager.installApp(deviceInfo, testTask.getAppFile().getAbsolutePath(), reportLogger);
-    }
 }

--- a/agent/src/main/java/com/microsoft/hydralab/agent/runner/smart/SmartRunner.java
+++ b/agent/src/main/java/com/microsoft/hydralab/agent/runner/smart/SmartRunner.java
@@ -7,32 +7,29 @@ import cn.hutool.core.img.gif.AnimatedGifEncoder;
 import cn.hutool.core.lang.Assert;
 import com.alibaba.fastjson.JSONArray;
 import com.alibaba.fastjson.JSONObject;
-import com.microsoft.hydralab.common.util.Const;
+import com.microsoft.hydralab.agent.runner.TestRunner;
+import com.microsoft.hydralab.agent.runner.TestTaskRunCallback;
 import com.microsoft.hydralab.common.entity.agent.SmartTestParam;
 import com.microsoft.hydralab.common.entity.common.AndroidTestUnit;
 import com.microsoft.hydralab.common.entity.common.DeviceInfo;
 import com.microsoft.hydralab.common.entity.common.DeviceTestTask;
 import com.microsoft.hydralab.common.entity.common.TestTask;
 import com.microsoft.hydralab.common.logger.LogCollector;
+import com.microsoft.hydralab.common.management.DeviceManager;
 import com.microsoft.hydralab.common.management.impl.IOSDeviceManager;
-import com.microsoft.hydralab.agent.runner.TestRunner;
-import com.microsoft.hydralab.agent.runner.TestTaskRunCallback;
 import com.microsoft.hydralab.common.screen.ScreenRecorder;
+import com.microsoft.hydralab.common.util.Const;
 import com.microsoft.hydralab.common.util.ThreadUtils;
 import org.slf4j.Logger;
-import org.springframework.stereotype.Service;
 
-import javax.annotation.Resource;
 import javax.imageio.ImageIO;
 import java.io.File;
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 
-@Service("smartRunner")
 public class SmartRunner extends TestRunner {
     private final AnimatedGifEncoder e = new AnimatedGifEncoder();
-    @Resource
-    SmartTestUtil smartTestUtil;
+    private final SmartTestUtil smartTestUtil;
     private LogCollector logCollector;
     private ScreenRecorder deviceScreenRecorder;
     private long recordingStartTimeMillis;
@@ -40,72 +37,46 @@ public class SmartRunner extends TestRunner {
     private String pkgName;
     private File gifFile;
     private SmartTestParam smartTestParam;
-    private AndroidTestUnit ongoingSmartTest;
 
-    @Override
-    public void runTestOnDevice(TestTask testTask, DeviceInfo deviceInfo, Logger logger) {
-        runSmartTest(deviceInfo, testTask, testTaskRunCallback, logger);
+    public SmartRunner(DeviceManager deviceManager, TestTaskRunCallback testTaskRunCallback, SmartTestUtil smartTestUtil) {
+        super(deviceManager, testTaskRunCallback);
+        this.smartTestUtil = smartTestUtil;
     }
 
-    private void runSmartTest(DeviceInfo deviceInfo, TestTask testTask, TestTaskRunCallback testTaskRunCallback, Logger logger) {
-        checkTestTaskCancel(testTask);
-        logger.info("Start running tests {}, timeout {}s", testTask.getTestSuite(), testTask.getTimeOutSecond());
+    @Override
+    protected void run(DeviceInfo deviceInfo, TestTask testTask, DeviceTestTask deviceTestTask) throws Exception {
 
-        DeviceTestTask deviceTestTask = initDeviceTestTask(deviceInfo, testTask, logger);
-        deviceTestTask.setTotalCount(testTask.getDeviceTestCount());
-        File deviceTestResultFolder = deviceTestTask.getDeviceTestResultFolder();
-        testTask.addTestedDeviceResult(deviceTestTask);
-        checkTestTaskCancel(testTask);
-
-        Logger reportLogger = null;
+        Logger reportLogger = deviceTestTask.getLogger();
 
         pkgName = testTask.getPkgName();
 
-        try {
-            reportLogger = deviceTestTask.getLogger();
-            initDevice(deviceInfo, testTask, reportLogger);
+        /** start Record **/
+        logCollector = deviceManager.getLogCollector(deviceInfo, pkgName, deviceTestTask, reportLogger);
+        deviceScreenRecorder = deviceManager.getScreenRecorder(deviceInfo, deviceTestTask.getDeviceTestResultFolder(), reportLogger);
+        startRecording(deviceInfo, deviceTestTask, testTask.getTimeOutSecond(), reportLogger);
 
-            /** start Record **/
-            logCollector = deviceManager.getLogCollector(deviceInfo, pkgName, deviceTestTask, logger);
-            deviceScreenRecorder = deviceManager.getScreenRecorder(deviceInfo, deviceTestTask.getDeviceTestResultFolder(), reportLogger);
-            startRecording(deviceInfo, deviceTestTask, testTask.getTimeOutSecond(), logger);
+        /** run the test */
+        reportLogger.info("Start Smart test");
+        checkTestTaskCancel(testTask);
+        deviceTestTask.setTestStartTimeMillis(System.currentTimeMillis());
 
-            /** run the test */
-            reportLogger.info("Start Smart test");
+        /** init smart_test arg */
+        //TODO choose model before starting test task
+        smartTestParam = new SmartTestParam(testTask.getAppFile().getAbsolutePath(), deviceInfo, "0", "0", testTask.getMaxStepCount(), smartTestUtil.getFolderPath(), smartTestUtil.getStringFolderPath());
+
+        for (int i = 1; i <= testTask.getDeviceTestCount(); i++) {
             checkTestTaskCancel(testTask);
-            deviceTestTask.setTestStartTimeMillis(System.currentTimeMillis());
-
-            /** init smart_test arg */
-            //TODO choose model before starting test task
-            smartTestParam = new SmartTestParam(testTask.getAppFile().getAbsolutePath(), deviceInfo, "0", "0", testTask.getMaxStepCount(), smartTestUtil.getFolderPath(), smartTestUtil.getStringFolderPath());
-
-            for (int i = 1; i <= testTask.getDeviceTestCount(); i++) {
-                checkTestTaskCancel(testTask);
-                runSmartTestOnce(i, deviceInfo, deviceTestTask, reportLogger);
-            }
-            testRunEnded(deviceInfo, deviceTestTask);
-            /** set paths */
-            String absoluteReportPath = deviceTestResultFolder.getAbsolutePath();
-            deviceTestTask.setTestXmlReportPath(deviceManager.getTestBaseRelPathInUrl(new File(absoluteReportPath)));
-            File gifFile = getGifFile();
-            if (gifFile.exists() && gifFile.length() > 0) {
-                deviceTestTask.setTestGifPath(deviceManager.getTestBaseRelPathInUrl(gifFile));
-            }
-
-        } catch (Exception e) {
-            if (reportLogger != null) {
-                reportLogger.info(deviceInfo.getSerialNum() + ": " + e.getMessage(), e);
-            } else {
-                logger.info(deviceInfo.getSerialNum() + ": " + e.getMessage(), e);
-            }
-            String errorStr = e.getClass().getName() + ": " + e.getMessage();
-            if (errorStr.length() > 255) {
-                errorStr = errorStr.substring(0, 254);
-            }
-            deviceTestTask.setErrorInProcess(errorStr);
-        } finally {
-            afterTest(deviceInfo, testTask, deviceTestTask, testTaskRunCallback, reportLogger);
+            runSmartTestOnce(i, deviceInfo, deviceTestTask, reportLogger);
         }
+        testRunEnded(deviceInfo, deviceTestTask);
+        /** set paths */
+        String absoluteReportPath = deviceTestTask.getDeviceTestResultFolder().getAbsolutePath();
+        deviceTestTask.setTestXmlReportPath(deviceManager.getTestBaseRelPathInUrl(new File(absoluteReportPath)));
+        File gifFile = getGifFile();
+        if (gifFile.exists() && gifFile.length() > 0) {
+            deviceTestTask.setTestGifPath(deviceManager.getTestBaseRelPathInUrl(gifFile));
+        }
+
     }
 
     public void startRecording(DeviceInfo deviceInfo, DeviceTestTask deviceTestTask, int maxTime, Logger logger) {
@@ -139,7 +110,7 @@ public class SmartRunner extends TestRunner {
         final int unitIndex = ++index;
         String title = "Smart_Test(" + i + ")";
 
-        ongoingSmartTest = new AndroidTestUnit();
+        AndroidTestUnit ongoingSmartTest = new AndroidTestUnit();
 
         ongoingSmartTest.setNumtests(deviceTestTask.getTotalCount());
         ongoingSmartTest.setStartTimeMillis(System.currentTimeMillis());
@@ -224,7 +195,7 @@ public class SmartRunner extends TestRunner {
     }
 
     @Override
-    public void reInstallApp(DeviceInfo deviceInfo, TestTask testTask, Logger reportLogger) throws Exception {
+    protected void reInstallApp(DeviceInfo deviceInfo, TestTask testTask, Logger reportLogger) throws Exception {
         if (testTask.getRequireReinstall() || deviceManager instanceof IOSDeviceManager) {
             deviceManager.uninstallApp(deviceInfo, testTask.getPkgName(), reportLogger);
             ThreadUtils.safeSleep(1000);

--- a/agent/src/main/java/com/microsoft/hydralab/agent/runner/smart/SmartRunner.java
+++ b/agent/src/main/java/com/microsoft/hydralab/agent/runner/smart/SmartRunner.java
@@ -194,16 +194,4 @@ public class SmartRunner extends TestRunner {
         logCollector.stopAndAnalyse();
     }
 
-    @Override
-    protected void reInstallApp(DeviceInfo deviceInfo, TestTask testTask, Logger reportLogger) throws Exception {
-        if (testTask.getRequireReinstall() || deviceManager instanceof IOSDeviceManager) {
-            deviceManager.uninstallApp(deviceInfo, testTask.getPkgName(), reportLogger);
-            ThreadUtils.safeSleep(1000);
-        } else if (testTask.getRequireClearData()) {
-            deviceManager.resetPackage(deviceInfo, testTask.getPkgName(), reportLogger);
-        }
-        checkTestTaskCancel(testTask);
-
-        deviceManager.installApp(deviceInfo, testTask.getAppFile().getAbsolutePath(), reportLogger);
-    }
 }

--- a/agent/src/main/java/com/microsoft/hydralab/agent/service/TestTaskEngineService.java
+++ b/agent/src/main/java/com/microsoft/hydralab/agent/service/TestTaskEngineService.java
@@ -1,5 +1,6 @@
 package com.microsoft.hydralab.agent.service;
 
+import com.microsoft.hydralab.agent.config.TestRunnerConfig;
 import com.microsoft.hydralab.agent.runner.DeviceTaskControlExecutor;
 import com.microsoft.hydralab.agent.runner.TestRunner;
 import com.microsoft.hydralab.agent.runner.TestTaskRunCallback;
@@ -48,15 +49,13 @@ public class TestTaskEngineService implements TestTaskRunCallback {
     public TestTask runTestTask(TestTaskSpec testTaskSpec) {
         updateTaskSpecWithDefaultValues(testTaskSpec);
         log.info("TestTaskSpec: {}", testTaskSpec);
+        TestTask testTask = TestTask.convertToTestTask(testTaskSpec);
+        setupTestDir(testTask);
 
-        String beanName = TestTask.TestRunnerMap.get(testTaskSpec.runningType);
+        String beanName = TestRunnerConfig.TestRunnerMap.get(testTaskSpec.runningType);
         TestRunner runner = applicationContext.getBean(beanName, TestRunner.class);
 
         Set<DeviceInfo> chosenDevices = chooseDevices(testTaskSpec, runner);
-
-        TestTask testTask = TestTask.convertToTestTask(testTaskSpec);
-
-        setupTestDir(testTask);
 
         onTaskStart(testTask);
         DeviceTaskControl deviceTaskControl = deviceTaskControlExecutor.runForAllDeviceAsync(chosenDevices, new DeviceTaskControlExecutor.DeviceTask() {

--- a/agent/src/test/java/com/microsoft/hydralab/agent/runner/TestRunnerTest.java
+++ b/agent/src/test/java/com/microsoft/hydralab/agent/runner/TestRunnerTest.java
@@ -1,5 +1,6 @@
 package com.microsoft.hydralab.agent.runner;
 
+import com.microsoft.hydralab.agent.service.TestTaskEngineService;
 import com.microsoft.hydralab.agent.test.BaseTest;
 import com.microsoft.hydralab.common.entity.common.DeviceInfo;
 import com.microsoft.hydralab.common.entity.common.DeviceTestTask;
@@ -17,17 +18,18 @@ import java.io.File;
 public class TestRunnerTest extends BaseTest {
     @Resource
     DeviceManager deviceManager;
+    @Resource
+    TestTaskEngineService testTaskEngineService;
     final Logger logger = LoggerFactory.getLogger(TestRunnerTest.class);
 
     @Test
     public void createTestRunnerAndInitDeviceTest() {
-        TestRunner testRunner = new TestRunner() {
+        TestRunner testRunner = new TestRunner(deviceManager, testTaskEngineService) {
             @Override
-            public void runTestOnDevice(TestTask testTask, DeviceInfo deviceInfo, Logger logger) {
+            protected void run(DeviceInfo deviceInfo, TestTask testTask, DeviceTestTask deviceTestTask) throws Exception {
 
             }
         };
-        testRunner.deviceManager = deviceManager;
 
         DeviceInfo deviceInfo = Mockito.mock(DeviceInfo.class);
         Mockito.when(deviceInfo.getSerialNum()).thenReturn("build");
@@ -40,7 +42,7 @@ public class TestRunnerTest extends BaseTest {
         testTask.setResourceDir(resourceDir);
         testTask.setTestSuite("TestSuite");
 
-        DeviceTestTask deviceTestTask = testRunner.initDeviceTestTask(deviceInfo, testTask, logger);
+        DeviceTestTask deviceTestTask = testRunner.buildDeviceTestTask(deviceInfo, testTask, logger);
 
         deviceTestTask.getLogger().info("Test DeviceTestTask logging function");
         deviceTestTask.getLogger().info("DeviceTestTask InstrumentReportPath {}", deviceTestTask.getInstrumentReportPath());

--- a/agent/src/test/java/com/microsoft/hydralab/agent/service/TestTaskEngineServiceTest.java
+++ b/agent/src/test/java/com/microsoft/hydralab/agent/service/TestTaskEngineServiceTest.java
@@ -1,5 +1,6 @@
 package com.microsoft.hydralab.agent.service;
 
+import com.microsoft.hydralab.agent.config.TestRunnerConfig;
 import com.microsoft.hydralab.agent.runner.TestRunner;
 import com.microsoft.hydralab.agent.runner.espresso.EspressoRunner;
 import com.microsoft.hydralab.agent.test.BaseTest;
@@ -34,7 +35,7 @@ public class TestTaskEngineServiceTest extends BaseTest {
         taskSpecForGroupDevice.testFileSet = new TestFileSet();
         taskSpecForGroupDevice.groupDevices = "TestDeviceSerial1,TestDeviceSerial2";
 
-        String beanName = TestTask.TestRunnerMap.get(taskSpecForGroupDevice.runningType);
+        String beanName = TestRunnerConfig.TestRunnerMap.get(taskSpecForGroupDevice.runningType);
         TestRunner runner = applicationContext.getBean(beanName, TestRunner.class);
         baseLogger.info("Try to get bean by name: " + taskSpecForGroupDevice);
 

--- a/common/src/main/java/com/microsoft/hydralab/common/entity/common/TestTask.java
+++ b/common/src/main/java/com/microsoft/hydralab/common/entity/common/TestTask.java
@@ -299,16 +299,6 @@ public class TestTask {
         String T2C_JSON_TEST = "T2C_JSON";
     }
 
-    public static Map<String, String> TestRunnerMap = new HashMap<>() {{
-        put(TestRunningType.INSTRUMENTATION, "espressoRunner");
-        put(TestRunningType.APPIUM, "appiumRunner");
-        put(TestRunningType.APPIUM_CROSS, "appiumCrossRunner");
-        put(TestRunningType.SMART_TEST, "smartRunner");
-        put(TestRunningType.MONKEY_TEST, "adbMonkeyRunner");
-        put(TestRunningType.APPIUM_MONKEY_TEST, "appiumMonkeyRunner");
-        put(TestRunningType.T2C_JSON_TEST, "t2cRunner");
-    }};
-
     public interface TestFrameworkType {
         String JUNIT4 = "JUnit4";
         String JUNIT5 = "JUnit5";

--- a/common/src/main/java/com/microsoft/hydralab/common/logger/impl/ADBLogcatCollector.java
+++ b/common/src/main/java/com/microsoft/hydralab/common/logger/impl/ADBLogcatCollector.java
@@ -8,6 +8,7 @@ import com.microsoft.hydralab.common.logger.LogCollector;
 import com.microsoft.hydralab.common.management.DeviceManager;
 import com.microsoft.hydralab.common.util.ADBOperateUtil;
 import com.microsoft.hydralab.common.util.LogUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 
 import java.io.BufferedReader;
@@ -27,7 +28,6 @@ public class ADBLogcatCollector implements LogCollector {
     ADBOperateUtil adbOperateUtil;
     private boolean started;
     private String loggerFilePath;
-    private boolean collectCrash;
 
     public ADBLogcatCollector(DeviceManager deviceManager, ADBOperateUtil adbOperateUtil, DeviceInfo deviceInfo, String pkgName, DeviceTestTask deviceTestResult, Logger logger) {
         this.deviceManager = deviceManager;
@@ -79,14 +79,14 @@ public class ADBLogcatCollector implements LogCollector {
 
             try (BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(process.getInputStream(), StandardCharsets.UTF_8))) {
                 String line;
-                collectCrash = false;
+                boolean collectCrash = false;
                 StringBuilder crashLines = new StringBuilder();
                 while ((line = bufferedReader.readLine()) != null) {
                     if (collectCrash) {
                         if (!line.contains(" E ") && !line.contains(" F ")) {
                             collectCrash = false;
                         } else {
-                            if (line.contains(".launcher.")) {
+                            if (line.contains(pkgName)) {
                                 crashLines.append("<b>").append(line).append("</b>").append("\n");
                             } else {
                                 crashLines.append(line).append("\n");
@@ -115,6 +115,6 @@ public class ADBLogcatCollector implements LogCollector {
 
     @Override
     public boolean isCrashFound() {
-        return collectCrash;
+        return StringUtils.isNotEmpty(deviceTestResult.getCrashStack());
     }
 }


### PR DESCRIPTION
- Test runner lifecycle: buildDeviceTestTask -> setUp -> run -> tearDown
- Remove runner class dependencies for Spring annotations, create TestRunnerConfig.java to centralize the configuration.
- Inline some runner members as local var.
- Change the method access of reInstallApp
- Fix bug in ADBLogcatCollector isCrashFound() method.