### PR TITLE
Add image of contributors to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,8 +110,9 @@ We are happy to hear your ideas for the future of Hydra Lab. Check the [GitHub I
 
 The Hydra Lab team encourages community feedback and contributions. Thank you for your interest in making Hydra Lab better!
 
-<!--TODO: Generate an image of contributors to keep our README.md in sync. The image can be generated after the status of repo is public.  -->
-<!--TODO: For more details, please refer: https://contrib.rocks/preview?repo=microsoft%2Fjust  -->
+<a href="https://github.com/Microsoft/hydralab/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=Microsoft/hydralab" />
+</a>
 
 <span id="contact"></span>
 ## Contact Us


### PR DESCRIPTION
Generate an image of contributors to keep the README.md in sync.

![image](https://user-images.githubusercontent.com/30514480/208595883-84e38045-06f7-48f5-911f-f457d5b91442.png)


For more details considering contributors image, please head over to [contrib.rocks](https://contrib.rocks/preview?repo=Microsoft%2Fhydralab)