### PR TITLE
[Refactor] Rename DeviceTestTask to TestRun

### DIFF
--- a/TrickyDesign.md
+++ b/TrickyDesign.md
@@ -11,6 +11,6 @@ com.microsoft.hydralab.agent.runner.smart.SmartTestLog
 We'd better create a new POJO to wrap the info.
 Related references:
 - com.microsoft.hydralab.agent.runner.espresso.testStarted
-- com.microsoft.hydralab.common.entity.common.DeviceTestTask.addNewTimeTag
+- com.microsoft.hydralab.common.entity.common.TestRun.addNewTimeTag
 - com.microsoft.hydralab.center.controller.TestDetailController.deviceTaskInfo
 - react/src/component/VideoNavView.jsx:110

--- a/agent/doc/UML/logger_file_design.puml
+++ b/agent/doc/UML/logger_file_design.puml
@@ -6,12 +6,12 @@ note top of DeviceLogger
 deviceLogBaseDir/device.getName()/device_control.log
 end note
 
-object DeviceTestTaskLogger
-note bottom of DeviceTestTaskLogger
+object TestRunLogger
+note bottom of TestRunLogger
 DeviceTestResultFolder/loggerNamePrefix_dateInfo.log
 end note
 
-DeviceTestTaskLogger -u-|> DeviceLogger
+TestRunLogger -u-|> DeviceLogger
 @enduml
 
 @startuml loggers

--- a/agent/doc/UML/test_runner_design.puml
+++ b/agent/doc/UML/test_runner_design.puml
@@ -1,6 +1,6 @@
 @startuml test_runners_classes
 abstract class TestRunner {
-    #buildDeviceTestTask(...)
+    #createTestRun(...)
     #setUp(TestTask)
     #run(TestTaskSpec)
     #tearDown(...)
@@ -132,13 +132,13 @@ Runner *--> TestRunnerListener
 
 entity (TestTaskSpec)
 entity (TestTask)
-entity (DeviceTestTask)
+entity (TestRun)
 entity (AndroidTestUnit)
 
 
 TestTaskSpec -- TestTask: is mapped to
-TestTask *--> DeviceTestTask: contain a list of
-DeviceTestTask *--> AndroidTestUnit: contain a list of
+TestTask *--> TestRun: contain a list of
+TestRun *--> AndroidTestUnit: contain a list of
 @enduml
 
 @startuml test_objects

--- a/agent/src/main/java/com/microsoft/hydralab/agent/runner/TestRunner.java
+++ b/agent/src/main/java/com/microsoft/hydralab/agent/runner/TestRunner.java
@@ -88,17 +88,17 @@ public abstract class TestRunner {
 
     protected TestRun createTestRun(DeviceInfo deviceInfo, TestTask testTask, Logger parentLogger) {
         TestRun testRun = new TestRun(deviceInfo.getSerialNum(), deviceInfo.getName(), testTask.getId());
-        File deviceTestResultFolder = new File(testTask.getResourceDir(), deviceInfo.getSerialNum());
-        parentLogger.info("DeviceTestResultFolder {}", deviceTestResultFolder);
-        if (!deviceTestResultFolder.exists()) {
-            if (!deviceTestResultFolder.mkdirs()) {
-                throw new RuntimeException("deviceTestResultFolder.mkdirs() failed: " + deviceTestResultFolder);
+        File testRunResultFolder = new File(testTask.getResourceDir(), deviceInfo.getSerialNum());
+        parentLogger.info("DeviceTestResultFolder {}", testRunResultFolder);
+        if (!testRunResultFolder.exists()) {
+            if (!testRunResultFolder.mkdirs()) {
+                throw new RuntimeException("testRunResultFolder.mkdirs() failed: " + testRunResultFolder);
             }
         }
 
-        testRun.setTestRunResultFolder(deviceTestResultFolder);
-        Logger loggerForDeviceTestTask = createLoggerForDeviceTestTask(testRun, testTask.getTestSuite(), parentLogger);
-        testRun.setLogger(loggerForDeviceTestTask);
+        testRun.setTestRunResultFolder(testRunResultFolder);
+        Logger loggerForTestRun = createLoggerForTestRun(testRun, testTask.getTestSuite(), parentLogger);
+        testRun.setLogger(loggerForTestRun);
         testTask.addTestedDeviceResult(testRun);
         return testRun;
     }
@@ -216,7 +216,7 @@ public abstract class TestRunner {
         return false;
     }
 
-    private Logger createLoggerForDeviceTestTask(TestRun testRun, String loggerNamePrefix, Logger parentLogger) {
+    private Logger createLoggerForTestRun(TestRun testRun, String loggerNamePrefix, Logger parentLogger) {
         parentLogger.info("Start setup report child parentLogger");
         String dateInfo = DateUtil.fileNameDateFormat.format(new Date());
         File instrumentLogFile = new File(testRun.getTestRunResultFolder(), loggerNamePrefix + "_" + dateInfo + ".log");

--- a/agent/src/main/java/com/microsoft/hydralab/agent/runner/TestRunner.java
+++ b/agent/src/main/java/com/microsoft/hydralab/agent/runner/TestRunner.java
@@ -96,7 +96,7 @@ public abstract class TestRunner {
             }
         }
 
-        testRun.setTestRunResultFolder(testRunResultFolder);
+        testRun.setResultFolder(testRunResultFolder);
         Logger loggerForTestRun = createLoggerForTestRun(testRun, testTask.getTestSuite(), parentLogger);
         testRun.setLogger(loggerForTestRun);
         testTask.addTestedDeviceResult(testRun);
@@ -219,7 +219,7 @@ public abstract class TestRunner {
     private Logger createLoggerForTestRun(TestRun testRun, String loggerNamePrefix, Logger parentLogger) {
         parentLogger.info("Start setup report child parentLogger");
         String dateInfo = DateUtil.fileNameDateFormat.format(new Date());
-        File instrumentLogFile = new File(testRun.getTestRunResultFolder(), loggerNamePrefix + "_" + dateInfo + ".log");
+        File instrumentLogFile = new File(testRun.getResultFolder(), loggerNamePrefix + "_" + dateInfo + ".log");
         // make sure it's a child logger of the parentLogger
         String loggerName = parentLogger.getName() + ".test." + dateInfo;
         Logger reportLogger = LogUtils.getLoggerWithRollingFileAppender(loggerName, instrumentLogFile.getAbsolutePath(), "%d %p -- %m%n");

--- a/agent/src/main/java/com/microsoft/hydralab/agent/runner/TestRunner.java
+++ b/agent/src/main/java/com/microsoft/hydralab/agent/runner/TestRunner.java
@@ -5,7 +5,7 @@ package com.microsoft.hydralab.agent.runner;
 import cn.hutool.core.lang.Assert;
 import com.microsoft.hydralab.common.entity.common.DeviceAction;
 import com.microsoft.hydralab.common.entity.common.DeviceInfo;
-import com.microsoft.hydralab.common.entity.common.DeviceTestTask;
+import com.microsoft.hydralab.common.entity.common.TestRun;
 import com.microsoft.hydralab.common.entity.common.TestTask;
 import com.microsoft.hydralab.common.management.DeviceManager;
 import com.microsoft.hydralab.common.management.impl.IOSDeviceManager;
@@ -40,24 +40,24 @@ public abstract class TestRunner {
         checkTestTaskCancel(testTask);
         logger.info("Start running tests {}, timeout {}s", testTask.getTestSuite(), testTask.getTimeOutSecond());
 
-        DeviceTestTask deviceTestTask = buildDeviceTestTask(deviceInfo, testTask, logger);
+        TestRun testRun = createTestRun(deviceInfo, testTask, logger);
         checkTestTaskCancel(testTask);
 
-        setUp(deviceInfo, testTask, deviceTestTask);
+        setUp(deviceInfo, testTask, testRun);
         checkTestTaskCancel(testTask);
         try {
-            runByFutureTask(deviceInfo, testTask, deviceTestTask);
+            runByFutureTask(deviceInfo, testTask, testRun);
         } catch (Exception e) {
-            deviceTestTask.getLogger().error(deviceInfo.getSerialNum() + ": " + e.getMessage(), e);
-            saveErrorSummary(deviceTestTask, e);
+            testRun.getLogger().error(deviceInfo.getSerialNum() + ": " + e.getMessage(), e);
+            saveErrorSummary(testRun, e);
         } finally {
-            tearDown(deviceInfo, testTask, deviceTestTask);
+            tearDown(deviceInfo, testTask, testRun);
         }
     }
 
-    private void runByFutureTask(DeviceInfo deviceInfo, TestTask testTask, DeviceTestTask deviceTestTask) throws Exception {
+    private void runByFutureTask(DeviceInfo deviceInfo, TestTask testTask, TestRun testRun) throws Exception {
         FutureTask<String> futureTask = new FutureTask<>(() -> {
-            run(deviceInfo, testTask, deviceTestTask);
+            run(deviceInfo, testTask, testRun);
             return null;
         });
         ThreadPoolUtil.TEST_EXECUTOR.execute(futureTask);
@@ -74,20 +74,20 @@ public abstract class TestRunner {
         }
     }
 
-    private static void saveErrorSummary(DeviceTestTask deviceTestTask, Exception e) {
+    private static void saveErrorSummary(TestRun testRun, Exception e) {
         String errorStr = e.getClass().getName() + ": " + e.getMessage();
         if (errorStr.length() > 255) {
             errorStr = errorStr.substring(0, 254);
         }
-        deviceTestTask.setErrorInProcess(errorStr);
+        testRun.setErrorInProcess(errorStr);
     }
 
     protected void checkTestTaskCancel(TestTask testTask) {
         Assert.isFalse(testTask.isCanceled(), "Task {} is canceled", testTask.getId());
     }
 
-    protected DeviceTestTask buildDeviceTestTask(DeviceInfo deviceInfo, TestTask testTask, Logger parentLogger) {
-        DeviceTestTask deviceTestTask = new DeviceTestTask(deviceInfo.getSerialNum(), deviceInfo.getName(), testTask.getId());
+    protected TestRun createTestRun(DeviceInfo deviceInfo, TestTask testTask, Logger parentLogger) {
+        TestRun testRun = new TestRun(deviceInfo.getSerialNum(), deviceInfo.getName(), testTask.getId());
         File deviceTestResultFolder = new File(testTask.getResourceDir(), deviceInfo.getSerialNum());
         parentLogger.info("DeviceTestResultFolder {}", deviceTestResultFolder);
         if (!deviceTestResultFolder.exists()) {
@@ -96,68 +96,68 @@ public abstract class TestRunner {
             }
         }
 
-        deviceTestTask.setDeviceTestResultFolder(deviceTestResultFolder);
-        Logger loggerForDeviceTestTask = createLoggerForDeviceTestTask(deviceTestTask, testTask.getTestSuite(), parentLogger);
-        deviceTestTask.setLogger(loggerForDeviceTestTask);
-        testTask.addTestedDeviceResult(deviceTestTask);
-        return deviceTestTask;
+        testRun.setTestRunResultFolder(deviceTestResultFolder);
+        Logger loggerForDeviceTestTask = createLoggerForDeviceTestTask(testRun, testTask.getTestSuite(), parentLogger);
+        testRun.setLogger(loggerForDeviceTestTask);
+        testTask.addTestedDeviceResult(testRun);
+        return testRun;
     }
 
-    protected void setUp(DeviceInfo deviceInfo, TestTask testTask, DeviceTestTask deviceTestTask) throws Exception {
+    protected void setUp(DeviceInfo deviceInfo, TestTask testTask, TestRun testRun) throws Exception {
         deviceInfo.killAll();
         // this key will be used to recover device status when lost the connection between agent and master
         deviceInfo.addCurrentTask(testTask);
 
         /* set up device */
-        deviceTestTask.getLogger().info("Start setup device");
-        deviceManager.testDeviceSetup(deviceInfo, deviceTestTask.getLogger());
-        deviceManager.wakeUpDevice(deviceInfo, deviceTestTask.getLogger());
+        testRun.getLogger().info("Start setup device");
+        deviceManager.testDeviceSetup(deviceInfo, testRun.getLogger());
+        deviceManager.wakeUpDevice(deviceInfo, testRun.getLogger());
         ThreadUtils.safeSleep(1000);
         checkTestTaskCancel(testTask);
-        reInstallApp(deviceInfo, testTask, deviceTestTask.getLogger());
-        reInstallTestApp(deviceInfo, testTask, deviceTestTask.getLogger());
+        reInstallApp(deviceInfo, testTask, testRun.getLogger());
+        reInstallTestApp(deviceInfo, testTask, testRun.getLogger());
 
         if (testTask.isThisForMicrosoftLauncher()) {
-            presetForMicrosoftLauncherApp(deviceInfo, testTask, deviceTestTask.getLogger());
+            presetForMicrosoftLauncherApp(deviceInfo, testTask, testRun.getLogger());
         }
         //execute actions
         if (testTask.getDeviceActions() != null) {
-            deviceTestTask.getLogger().info("Start executing setUp actions.");
-            actionExecutor.doActions(deviceManager, deviceInfo, deviceTestTask.getLogger(), testTask.getDeviceActions(), DeviceAction.When.SET_UP);
+            testRun.getLogger().info("Start executing setUp actions.");
+            actionExecutor.doActions(deviceManager, deviceInfo, testRun.getLogger(), testTask.getDeviceActions(), DeviceAction.When.SET_UP);
         }
 
-        deviceTestTask.getLogger().info("Start granting all package needed permissions device");
-        deviceManager.grantAllTaskNeededPermissions(deviceInfo, testTask, deviceTestTask.getLogger());
+        testRun.getLogger().info("Start granting all package needed permissions device");
+        deviceManager.grantAllTaskNeededPermissions(deviceInfo, testTask, testRun.getLogger());
 
         checkTestTaskCancel(testTask);
-        deviceManager.getScreenShot(deviceInfo, deviceTestTask.getLogger());
+        deviceManager.getScreenShot(deviceInfo, testRun.getLogger());
     }
 
-    protected abstract void run(DeviceInfo deviceInfo, TestTask testTask, DeviceTestTask deviceTestTask) throws Exception;
+    protected abstract void run(DeviceInfo deviceInfo, TestTask testTask, TestRun testRun) throws Exception;
 
-    protected void tearDown(DeviceInfo deviceInfo, TestTask testTask, DeviceTestTask deviceTestTask) {
+    protected void tearDown(DeviceInfo deviceInfo, TestTask testTask, TestRun testRun) {
         try {
-            String absoluteReportPath = xmlBuilder.buildTestResultXml(testTask, deviceTestTask);
-            deviceTestTask.setTestXmlReportPath(deviceManager.getTestBaseRelPathInUrl(new File(absoluteReportPath)));
+            String absoluteReportPath = xmlBuilder.buildTestResultXml(testTask, testRun);
+            testRun.setTestXmlReportPath(deviceManager.getTestBaseRelPathInUrl(new File(absoluteReportPath)));
         } catch (Exception e) {
-            deviceTestTask.getLogger().error("Error in buildTestResultXml", e);
+            testRun.getLogger().error("Error in buildTestResultXml", e);
         }
         if (testTaskRunCallback != null) {
             try {
-                testTaskRunCallback.onOneDeviceComplete(testTask, deviceInfo, deviceTestTask.getLogger(), deviceTestTask);
+                testTaskRunCallback.onOneDeviceComplete(testTask, deviceInfo, testRun.getLogger(), testRun);
             } catch (Exception e) {
-                deviceTestTask.getLogger().error("Error in onOneDeviceComplete", e);
+                testRun.getLogger().error("Error in onOneDeviceComplete", e);
             }
         }
-        deviceManager.testDeviceUnset(deviceInfo, deviceTestTask.getLogger());
+        deviceManager.testDeviceUnset(deviceInfo, testRun.getLogger());
         //execute actions
         if (testTask.getDeviceActions() != null) {
-            deviceTestTask.getLogger().info("Start executing tearDown actions.");
-            actionExecutor.doActions(deviceManager, deviceInfo, deviceTestTask.getLogger(), testTask.getDeviceActions(), DeviceAction.When.TEAR_DOWN);
+            testRun.getLogger().info("Start executing tearDown actions.");
+            actionExecutor.doActions(deviceManager, deviceInfo, testRun.getLogger(), testTask.getDeviceActions(), DeviceAction.When.TEAR_DOWN);
         }
 
-        deviceTestTask.getLogger().info("Start Close/finish resource");
-        LogUtils.releaseLogger(deviceTestTask.getLogger());
+        testRun.getLogger().info("Start Close/finish resource");
+        LogUtils.releaseLogger(testRun.getLogger());
     }
 
     private void presetForMicrosoftLauncherApp(DeviceInfo deviceInfo, TestTask testTask, Logger reportLogger) {
@@ -216,15 +216,15 @@ public abstract class TestRunner {
         return false;
     }
 
-    private Logger createLoggerForDeviceTestTask(DeviceTestTask deviceTestTask, String loggerNamePrefix, Logger parentLogger) {
+    private Logger createLoggerForDeviceTestTask(TestRun testRun, String loggerNamePrefix, Logger parentLogger) {
         parentLogger.info("Start setup report child parentLogger");
         String dateInfo = DateUtil.fileNameDateFormat.format(new Date());
-        File instrumentLogFile = new File(deviceTestTask.getDeviceTestResultFolder(), loggerNamePrefix + "_" + dateInfo + ".log");
+        File instrumentLogFile = new File(testRun.getTestRunResultFolder(), loggerNamePrefix + "_" + dateInfo + ".log");
         // make sure it's a child logger of the parentLogger
         String loggerName = parentLogger.getName() + ".test." + dateInfo;
         Logger reportLogger = LogUtils.getLoggerWithRollingFileAppender(loggerName, instrumentLogFile.getAbsolutePath(), "%d %p -- %m%n");
         // TODO the getTestBaseRelPathInUrl method shouldn't be in deviceManager, testBaseDir should be managed by agent
-        deviceTestTask.setInstrumentReportPath(deviceManager.getTestBaseRelPathInUrl(instrumentLogFile));
+        testRun.setInstrumentReportPath(deviceManager.getTestBaseRelPathInUrl(instrumentLogFile));
 
         return reportLogger;
     }

--- a/agent/src/main/java/com/microsoft/hydralab/agent/runner/TestTaskRunCallback.java
+++ b/agent/src/main/java/com/microsoft/hydralab/agent/runner/TestTaskRunCallback.java
@@ -3,7 +3,7 @@
 package com.microsoft.hydralab.agent.runner;
 
 import com.microsoft.hydralab.common.entity.common.DeviceInfo;
-import com.microsoft.hydralab.common.entity.common.DeviceTestTask;
+import com.microsoft.hydralab.common.entity.common.TestRun;
 import com.microsoft.hydralab.common.entity.common.TestTask;
 import org.slf4j.Logger;
 
@@ -11,7 +11,7 @@ public interface TestTaskRunCallback {
     void onTaskStart(TestTask testTask);
     void onTaskComplete(TestTask testTask);
 
-    void onOneDeviceComplete(TestTask testTask, DeviceInfo deviceControl, Logger logger, DeviceTestTask result);
+    void onOneDeviceComplete(TestTask testTask, DeviceInfo deviceControl, Logger logger, TestRun result);
 
     void onDeviceOffline(TestTask testTask);
 }

--- a/agent/src/main/java/com/microsoft/hydralab/agent/runner/XmlBuilder.java
+++ b/agent/src/main/java/com/microsoft/hydralab/agent/runner/XmlBuilder.java
@@ -52,7 +52,7 @@ public class XmlBuilder {
         Element testSuite = buildTestSuite(document, testTask, testRun);
         document.appendChild(testSuite);
 
-        File xmlFile = File.createTempFile(TEST_RESULT_FILE_PREFIX, TEST_RESULT_FILE_SUFFIX, testRun.getTestRunResultFolder());
+        File xmlFile = File.createTempFile(TEST_RESULT_FILE_PREFIX, TEST_RESULT_FILE_SUFFIX, testRun.getResultFolder());
         transferToFile(document, xmlFile);
         return xmlFile.getAbsolutePath();
     }

--- a/agent/src/main/java/com/microsoft/hydralab/agent/runner/XmlBuilder.java
+++ b/agent/src/main/java/com/microsoft/hydralab/agent/runner/XmlBuilder.java
@@ -3,7 +3,7 @@
 package com.microsoft.hydralab.agent.runner;
 
 import com.microsoft.hydralab.common.entity.common.AndroidTestUnit;
-import com.microsoft.hydralab.common.entity.common.DeviceTestTask;
+import com.microsoft.hydralab.common.entity.common.TestRun;
 import com.microsoft.hydralab.common.entity.common.TestTask;
 import com.microsoft.hydralab.common.util.DateUtil;
 import org.w3c.dom.Document;
@@ -45,35 +45,35 @@ public class XmlBuilder {
     private static final String TIMESTAMP = "timestamp";
     private static final String HOSTNAME = "hostname";
 
-    public String buildTestResultXml(TestTask testTask, DeviceTestTask deviceTestTask) throws Exception {
+    public String buildTestResultXml(TestTask testTask, TestRun testRun) throws Exception {
         DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
         DocumentBuilder db = factory.newDocumentBuilder();
         Document document = db.newDocument();
-        Element testSuite = buildTestSuite(document, testTask, deviceTestTask);
+        Element testSuite = buildTestSuite(document, testTask, testRun);
         document.appendChild(testSuite);
 
-        File xmlFile = File.createTempFile(TEST_RESULT_FILE_PREFIX, TEST_RESULT_FILE_SUFFIX, deviceTestTask.getDeviceTestResultFolder());
+        File xmlFile = File.createTempFile(TEST_RESULT_FILE_PREFIX, TEST_RESULT_FILE_SUFFIX, testRun.getTestRunResultFolder());
         transferToFile(document, xmlFile);
         return xmlFile.getAbsolutePath();
     }
 
-    private Element buildTestSuite(Document document, TestTask testTask, DeviceTestTask deviceTestTask) throws UnknownHostException {
+    private Element buildTestSuite(Document document, TestTask testTask, TestRun testRun) throws UnknownHostException {
         Element testSuite = document.createElement(TESTSUITE);
 
         testSuite.setAttribute(ATTR_NAME, testTask.getTestSuite());
-        testSuite.setAttribute(ATTR_TESTS, String.valueOf(deviceTestTask.getTotalCount()));
-        testSuite.setAttribute(ATTR_FAILURES, String.valueOf(deviceTestTask.getFailCount()));
-        testSuite.setAttribute(ATTR_TIME, Double.toString((double) (deviceTestTask.getTestEndTimeMillis() - deviceTestTask.getTestStartTimeMillis()) / 1000.f));
-        testSuite.setAttribute(TIMESTAMP, DateUtil.appCenterFormat2.format(DateUtil.localToUTC(new Date(deviceTestTask.getTestStartTimeMillis()))));
+        testSuite.setAttribute(ATTR_TESTS, String.valueOf(testRun.getTotalCount()));
+        testSuite.setAttribute(ATTR_FAILURES, String.valueOf(testRun.getFailCount()));
+        testSuite.setAttribute(ATTR_TIME, Double.toString((double) (testRun.getTestEndTimeMillis() - testRun.getTestStartTimeMillis()) / 1000.f));
+        testSuite.setAttribute(TIMESTAMP, DateUtil.appCenterFormat2.format(DateUtil.localToUTC(new Date(testRun.getTestStartTimeMillis()))));
         testSuite.setAttribute(HOSTNAME, InetAddress.getLocalHost().getHostName());
-        if (deviceTestTask.getTestUnitList() != null) {
-            testSuite.setAttribute(ATTR_SKIPPED, String.valueOf(deviceTestTask.getTotalCount() - deviceTestTask.getTestUnitList().size()));
-            for (AndroidTestUnit unitTest : deviceTestTask.getTestUnitList()) {
+        if (testRun.getTestUnitList() != null) {
+            testSuite.setAttribute(ATTR_SKIPPED, String.valueOf(testRun.getTotalCount() - testRun.getTestUnitList().size()));
+            for (AndroidTestUnit unitTest : testRun.getTestUnitList()) {
                 Element testCase = buildTestCase(document, unitTest);
                 testSuite.appendChild(testCase);
             }
         } else {
-            testSuite.setAttribute(ATTR_SKIPPED, String.valueOf(deviceTestTask.getTotalCount() - deviceTestTask.getFailCount()));
+            testSuite.setAttribute(ATTR_SKIPPED, String.valueOf(testRun.getTotalCount() - testRun.getFailCount()));
         }
         return testSuite;
     }

--- a/agent/src/main/java/com/microsoft/hydralab/agent/runner/appium/AppiumCrossRunner.java
+++ b/agent/src/main/java/com/microsoft/hydralab/agent/runner/appium/AppiumCrossRunner.java
@@ -4,7 +4,7 @@ package com.microsoft.hydralab.agent.runner.appium;
 
 import com.microsoft.hydralab.agent.runner.TestTaskRunCallback;
 import com.microsoft.hydralab.common.entity.common.DeviceInfo;
-import com.microsoft.hydralab.common.entity.common.DeviceTestTask;
+import com.microsoft.hydralab.common.entity.common.TestRun;
 import com.microsoft.hydralab.common.entity.common.TestTask;
 import com.microsoft.hydralab.common.management.DeviceManager;
 import org.slf4j.Logger;
@@ -18,10 +18,10 @@ public class AppiumCrossRunner extends AppiumRunner {
     }
 
     @Override
-    protected DeviceTestTask buildDeviceTestTask(DeviceInfo deviceInfo, TestTask testTask, Logger parentLogger) {
-        DeviceTestTask deviceTestTask = super.buildDeviceTestTask(deviceInfo, testTask, parentLogger);
+    protected TestRun createTestRun(DeviceInfo deviceInfo, TestTask testTask, Logger parentLogger) {
+        TestRun testRun = super.createTestRun(deviceInfo, testTask, parentLogger);
         String deviceName = System.getProperties().getProperty("os.name") + "-" + agentName + "-" + deviceInfo.getName();
-        deviceTestTask.setDeviceName(deviceName);
-        return deviceTestTask;
+        testRun.setDeviceName(deviceName);
+        return testRun;
     }
 }

--- a/agent/src/main/java/com/microsoft/hydralab/agent/runner/appium/AppiumListener.java
+++ b/agent/src/main/java/com/microsoft/hydralab/agent/runner/appium/AppiumListener.java
@@ -50,7 +50,7 @@ public class AppiumListener extends RunListener {
         this.logger = logger;
         this.pkgName = pkgName;
         logcatCollector = deviceManager.getLogCollector(deviceInfo, pkgName, deviceTestResult, logger);
-        deviceScreenRecorder = deviceManager.getScreenRecorder(deviceInfo, deviceTestResult.getTestRunResultFolder(), logger);
+        deviceScreenRecorder = deviceManager.getScreenRecorder(deviceInfo, deviceTestResult.getResultFolder(), logger);
     }
 
     public File getGifFile() {
@@ -86,7 +86,7 @@ public class AppiumListener extends RunListener {
 //            exception.printStackTrace();
 //        }
         logger.info("Start gif frames collection");
-        gifFile = new File(deviceTestResult.getTestRunResultFolder(), pkgName + ".gif");
+        gifFile = new File(deviceTestResult.getResultFolder(), pkgName + ".gif");
         e.start(gifFile.getAbsolutePath());
         e.setDelay(1000);
         e.setRepeat(0);

--- a/agent/src/main/java/com/microsoft/hydralab/agent/runner/appium/AppiumListener.java
+++ b/agent/src/main/java/com/microsoft/hydralab/agent/runner/appium/AppiumListener.java
@@ -6,7 +6,7 @@ import cn.hutool.core.img.ImgUtil;
 import cn.hutool.core.img.gif.AnimatedGifEncoder;
 import com.microsoft.hydralab.common.entity.common.AndroidTestUnit;
 import com.microsoft.hydralab.common.entity.common.DeviceInfo;
-import com.microsoft.hydralab.common.entity.common.DeviceTestTask;
+import com.microsoft.hydralab.common.entity.common.TestRun;
 import com.microsoft.hydralab.common.logger.LogCollector;
 import com.microsoft.hydralab.common.management.DeviceManager;
 import com.microsoft.hydralab.common.screen.ScreenRecorder;
@@ -24,7 +24,7 @@ import java.util.concurrent.TimeUnit;
 
 public class AppiumListener extends RunListener {
     private final DeviceInfo deviceInfo;
-    private final DeviceTestTask deviceTestResult;
+    private final TestRun deviceTestResult;
     private final LogCollector logcatCollector;
     private final ScreenRecorder deviceScreenRecorder;
     private final Logger logger;
@@ -43,14 +43,14 @@ public class AppiumListener extends RunListener {
     private int currentTestIndex = 0;
 
 
-    public AppiumListener(DeviceManager deviceManager, DeviceInfo deviceInfo, DeviceTestTask deviceTestResult, String pkgName, Logger logger) {
+    public AppiumListener(DeviceManager deviceManager, DeviceInfo deviceInfo, TestRun deviceTestResult, String pkgName, Logger logger) {
         this.deviceManager = deviceManager;
         this.deviceInfo = deviceInfo;
         this.deviceTestResult = deviceTestResult;
         this.logger = logger;
         this.pkgName = pkgName;
         logcatCollector = deviceManager.getLogCollector(deviceInfo, pkgName, deviceTestResult, logger);
-        deviceScreenRecorder = deviceManager.getScreenRecorder(deviceInfo, deviceTestResult.getDeviceTestResultFolder(), logger);
+        deviceScreenRecorder = deviceManager.getScreenRecorder(deviceInfo, deviceTestResult.getTestRunResultFolder(), logger);
     }
 
     public File getGifFile() {
@@ -86,7 +86,7 @@ public class AppiumListener extends RunListener {
 //            exception.printStackTrace();
 //        }
         logger.info("Start gif frames collection");
-        gifFile = new File(deviceTestResult.getDeviceTestResultFolder(), pkgName + ".gif");
+        gifFile = new File(deviceTestResult.getTestRunResultFolder(), pkgName + ".gif");
         e.start(gifFile.getAbsolutePath());
         e.setDelay(1000);
         e.setRepeat(0);

--- a/agent/src/main/java/com/microsoft/hydralab/agent/runner/appium/AppiumRunner.java
+++ b/agent/src/main/java/com/microsoft/hydralab/agent/runner/appium/AppiumRunner.java
@@ -41,7 +41,7 @@ public class AppiumRunner extends TestRunner {
 
         Logger reportLogger = testRun.getLogger();
         try {
-            File gifFile = runAndGetGif(testTask.getTestAppFile(), testTask.getTestSuite(), deviceInfo, testTask, testRun, testRun.getTestRunResultFolder(), reportLogger);
+            File gifFile = runAndGetGif(testTask.getTestAppFile(), testTask.getTestSuite(), deviceInfo, testTask, testRun, testRun.getResultFolder(), reportLogger);
             if (gifFile != null && gifFile.exists() && gifFile.length() > 0) {
                 testRun.setTestGifPath(deviceManager.getTestBaseRelPathInUrl(gifFile));
             }

--- a/agent/src/main/java/com/microsoft/hydralab/agent/runner/appium/AppiumRunner.java
+++ b/agent/src/main/java/com/microsoft/hydralab/agent/runner/appium/AppiumRunner.java
@@ -7,13 +7,11 @@ import com.microsoft.hydralab.agent.runner.TestTaskRunCallback;
 import com.microsoft.hydralab.appium.AppiumParam;
 import com.microsoft.hydralab.appium.ThreadParam;
 import com.microsoft.hydralab.common.entity.common.DeviceInfo;
-import com.microsoft.hydralab.common.entity.common.DeviceTestTask;
+import com.microsoft.hydralab.common.entity.common.TestRun;
 import com.microsoft.hydralab.common.entity.common.TestTask;
 import com.microsoft.hydralab.common.management.DeviceManager;
-import com.microsoft.hydralab.common.management.impl.IOSDeviceManager;
 import com.microsoft.hydralab.common.util.IOSUtils;
 import com.microsoft.hydralab.common.util.LogUtils;
-import com.microsoft.hydralab.common.util.ThreadUtils;
 import org.junit.internal.TextListener;
 import org.junit.platform.launcher.Launcher;
 import org.junit.platform.launcher.LauncherDiscoveryRequest;
@@ -39,13 +37,13 @@ public class AppiumRunner extends TestRunner {
     }
 
     @Override
-    protected void run(DeviceInfo deviceInfo, TestTask testTask, DeviceTestTask deviceTestTask) throws Exception {
+    protected void run(DeviceInfo deviceInfo, TestTask testTask, TestRun testRun) throws Exception {
 
-        Logger reportLogger = deviceTestTask.getLogger();
+        Logger reportLogger = testRun.getLogger();
         try {
-            File gifFile = runAndGetGif(testTask.getTestAppFile(), testTask.getTestSuite(), deviceInfo, testTask, deviceTestTask, deviceTestTask.getDeviceTestResultFolder(), reportLogger);
+            File gifFile = runAndGetGif(testTask.getTestAppFile(), testTask.getTestSuite(), deviceInfo, testTask, testRun, testRun.getTestRunResultFolder(), reportLogger);
             if (gifFile != null && gifFile.exists() && gifFile.length() > 0) {
-                deviceTestTask.setTestGifPath(deviceManager.getTestBaseRelPathInUrl(gifFile));
+                testRun.setTestGifPath(deviceManager.getTestBaseRelPathInUrl(gifFile));
             }
         } finally {
             //clear config
@@ -54,16 +52,16 @@ public class AppiumRunner extends TestRunner {
     }
 
     @Override
-    protected void tearDown(DeviceInfo deviceInfo, TestTask testTask, DeviceTestTask deviceTestTask) {
-        quitAppiumDrivers(deviceInfo, testTask, deviceTestTask.getLogger());
-        super.tearDown(deviceInfo, testTask, deviceTestTask);
+    protected void tearDown(DeviceInfo deviceInfo, TestTask testTask, TestRun testRun) {
+        quitAppiumDrivers(deviceInfo, testTask, testRun.getLogger());
+        super.tearDown(deviceInfo, testTask, testRun);
     }
 
     protected void quitAppiumDrivers(DeviceInfo deviceInfo, TestTask testTask, Logger reportLogger) {
         deviceManager.quitMobileAppiumDriver(deviceInfo, reportLogger);
     }
 
-    protected File runAndGetGif(File appiumJarFile, String appiumCommand, DeviceInfo deviceInfo, TestTask testTask, DeviceTestTask deviceTestTask, File deviceTestResultFolder, Logger reportLogger) {
+    protected File runAndGetGif(File appiumJarFile, String appiumCommand, DeviceInfo deviceInfo, TestTask testTask, TestRun testRun, File deviceTestResultFolder, Logger reportLogger) {
         //set appium test property
         reportLogger.info("Start set appium test property");
         Map<String, String> instrumentationArgs = testTask.getInstrumentationArgs();
@@ -76,7 +74,7 @@ public class AppiumRunner extends TestRunner {
         File gifFile = null;
         if (TestTask.TestFrameworkType.JUNIT5.equals(testTask.getFrameworkType())) {
             reportLogger.info("Start init listener");
-            Junit5Listener junit5Listener = new Junit5Listener(deviceManager, deviceInfo, deviceTestTask, testTask.getPkgName(), reportLogger);
+            Junit5Listener junit5Listener = new Junit5Listener(deviceManager, deviceInfo, testRun, testTask.getPkgName(), reportLogger);
 
             /** run the test */
             reportLogger.info("Start appium test with junit5");
@@ -88,7 +86,7 @@ public class AppiumRunner extends TestRunner {
         } else {
             /** xml report: parse listener */
             reportLogger.info("Start init listener");
-            AppiumListener listener = new AppiumListener(deviceManager, deviceInfo, deviceTestTask, testTask.getPkgName(), reportLogger);
+            AppiumListener listener = new AppiumListener(deviceManager, deviceInfo, testRun, testTask.getPkgName(), reportLogger);
 
             /** run the test */
             reportLogger.info("Start appium test with junit4");
@@ -100,7 +98,7 @@ public class AppiumRunner extends TestRunner {
         }
         /** set paths */
         String absoluteReportPath = deviceTestResultFolder.getAbsolutePath();
-        deviceTestTask.setTestXmlReportPath(deviceManager.getTestBaseRelPathInUrl(new File(absoluteReportPath)));
+        testRun.setTestXmlReportPath(deviceManager.getTestBaseRelPathInUrl(new File(absoluteReportPath)));
         return gifFile;
     }
 

--- a/agent/src/main/java/com/microsoft/hydralab/agent/runner/appium/Junit5Listener.java
+++ b/agent/src/main/java/com/microsoft/hydralab/agent/runner/appium/Junit5Listener.java
@@ -7,7 +7,7 @@ import cn.hutool.core.img.ImgUtil;
 import cn.hutool.core.img.gif.AnimatedGifEncoder;
 import com.microsoft.hydralab.common.entity.common.AndroidTestUnit;
 import com.microsoft.hydralab.common.entity.common.DeviceInfo;
-import com.microsoft.hydralab.common.entity.common.DeviceTestTask;
+import com.microsoft.hydralab.common.entity.common.TestRun;
 import com.microsoft.hydralab.common.logger.LogCollector;
 import com.microsoft.hydralab.common.management.DeviceManager;
 import com.microsoft.hydralab.common.screen.ScreenRecorder;
@@ -29,7 +29,7 @@ import java.util.concurrent.TimeUnit;
 public class Junit5Listener extends SummaryGeneratingListener {
     private final DeviceManager deviceManager;
     private final DeviceInfo deviceInfo;
-    private final DeviceTestTask deviceTestResult;
+    private final TestRun deviceTestResult;
     private final LogCollector logcatCollector;
     private final ScreenRecorder deviceScreenRecorder;
     private final Logger logger;
@@ -45,14 +45,14 @@ public class Junit5Listener extends SummaryGeneratingListener {
     private String currentTestName = "";
     private int currentTestIndex = 0;
 
-    public Junit5Listener(DeviceManager deviceManager, DeviceInfo deviceInfo, DeviceTestTask deviceTestResult, String pkgName, Logger logger) {
+    public Junit5Listener(DeviceManager deviceManager, DeviceInfo deviceInfo, TestRun deviceTestResult, String pkgName, Logger logger) {
         this.deviceManager = deviceManager;
         this.deviceInfo = deviceInfo;
         this.deviceTestResult = deviceTestResult;
         this.logger = logger;
         this.pkgName = pkgName;
         logcatCollector = deviceManager.getLogCollector(deviceInfo, pkgName, deviceTestResult, logger);
-        deviceScreenRecorder = deviceManager.getScreenRecorder(deviceInfo, deviceTestResult.getDeviceTestResultFolder(), logger);
+        deviceScreenRecorder = deviceManager.getScreenRecorder(deviceInfo, deviceTestResult.getTestRunResultFolder(), logger);
     }
 
     public File getGifFile() {
@@ -82,7 +82,7 @@ public class Junit5Listener extends SummaryGeneratingListener {
 
     private void startTools() {
         logger.info("Start gif frames collection");
-        gifFile = new File(deviceTestResult.getDeviceTestResultFolder(), pkgName + ".gif");
+        gifFile = new File(deviceTestResult.getTestRunResultFolder(), pkgName + ".gif");
         e.start(gifFile.getAbsolutePath());
         e.setDelay(1000);
         e.setRepeat(0);

--- a/agent/src/main/java/com/microsoft/hydralab/agent/runner/appium/Junit5Listener.java
+++ b/agent/src/main/java/com/microsoft/hydralab/agent/runner/appium/Junit5Listener.java
@@ -52,7 +52,7 @@ public class Junit5Listener extends SummaryGeneratingListener {
         this.logger = logger;
         this.pkgName = pkgName;
         logcatCollector = deviceManager.getLogCollector(deviceInfo, pkgName, deviceTestResult, logger);
-        deviceScreenRecorder = deviceManager.getScreenRecorder(deviceInfo, deviceTestResult.getTestRunResultFolder(), logger);
+        deviceScreenRecorder = deviceManager.getScreenRecorder(deviceInfo, deviceTestResult.getResultFolder(), logger);
     }
 
     public File getGifFile() {
@@ -82,7 +82,7 @@ public class Junit5Listener extends SummaryGeneratingListener {
 
     private void startTools() {
         logger.info("Start gif frames collection");
-        gifFile = new File(deviceTestResult.getTestRunResultFolder(), pkgName + ".gif");
+        gifFile = new File(deviceTestResult.getResultFolder(), pkgName + ".gif");
         e.start(gifFile.getAbsolutePath());
         e.setDelay(1000);
         e.setRepeat(0);

--- a/agent/src/main/java/com/microsoft/hydralab/agent/runner/appium/Junit5Listener.java
+++ b/agent/src/main/java/com/microsoft/hydralab/agent/runner/appium/Junit5Listener.java
@@ -29,7 +29,7 @@ import java.util.concurrent.TimeUnit;
 public class Junit5Listener extends SummaryGeneratingListener {
     private final DeviceManager deviceManager;
     private final DeviceInfo deviceInfo;
-    private final TestRun deviceTestResult;
+    private final TestRun testRun;
     private final LogCollector logcatCollector;
     private final ScreenRecorder deviceScreenRecorder;
     private final Logger logger;
@@ -45,14 +45,14 @@ public class Junit5Listener extends SummaryGeneratingListener {
     private String currentTestName = "";
     private int currentTestIndex = 0;
 
-    public Junit5Listener(DeviceManager deviceManager, DeviceInfo deviceInfo, TestRun deviceTestResult, String pkgName, Logger logger) {
+    public Junit5Listener(DeviceManager deviceManager, DeviceInfo deviceInfo, TestRun testRun, String pkgName, Logger logger) {
         this.deviceManager = deviceManager;
         this.deviceInfo = deviceInfo;
-        this.deviceTestResult = deviceTestResult;
+        this.testRun = testRun;
         this.logger = logger;
         this.pkgName = pkgName;
-        logcatCollector = deviceManager.getLogCollector(deviceInfo, pkgName, deviceTestResult, logger);
-        deviceScreenRecorder = deviceManager.getScreenRecorder(deviceInfo, deviceTestResult.getResultFolder(), logger);
+        logcatCollector = deviceManager.getLogCollector(deviceInfo, pkgName, testRun, logger);
+        deviceScreenRecorder = deviceManager.getScreenRecorder(deviceInfo, testRun.getResultFolder(), logger);
     }
 
     public File getGifFile() {
@@ -77,19 +77,19 @@ public class Junit5Listener extends SummaryGeneratingListener {
         recordingStartTimeMillis = System.currentTimeMillis();
         final String initializing = "Initializing";
         deviceInfo.setRunningTestName(initializing);
-        deviceTestResult.addNewTimeTag(initializing, 0);
+        testRun.addNewTimeTag(initializing, 0);
     }
 
     private void startTools() {
         logger.info("Start gif frames collection");
-        gifFile = new File(deviceTestResult.getResultFolder(), pkgName + ".gif");
+        gifFile = new File(testRun.getResultFolder(), pkgName + ".gif");
         e.start(gifFile.getAbsolutePath());
         e.setDelay(1000);
         e.setRepeat(0);
 
         logger.info("Start logcat collection");
         String logcatFilePath = logcatCollector.start();
-        deviceTestResult.setLogcatPath(deviceManager.getTestBaseRelPathInUrl(new File(logcatFilePath)));
+        testRun.setLogcatPath(deviceManager.getTestBaseRelPathInUrl(new File(logcatFilePath)));
     }
 
     @Override
@@ -98,9 +98,9 @@ public class Junit5Listener extends SummaryGeneratingListener {
         String runName = pkgName;
         int testCount = (int) getSummary().getTestsFoundCount();
         logEnter("testRunStarted", runName, testCount);
-        deviceTestResult.setTotalCount(testCount);
-        deviceTestResult.setTestStartTimeMillis(System.currentTimeMillis());
-        deviceTestResult.addNewTimeTag("testRunStarted", System.currentTimeMillis() - recordingStartTimeMillis);
+        testRun.setTotalCount(testCount);
+        testRun.setTestStartTimeMillis(System.currentTimeMillis());
+        testRun.addNewTimeTag("testRunStarted", System.currentTimeMillis() - recordingStartTimeMillis);
         deviceInfo.setRunningTestName(runName.substring(runName.lastIndexOf('.') + 1) + ".testRunStarted");
         logEnter(runName, testCount);
     }
@@ -113,15 +113,15 @@ public class Junit5Listener extends SummaryGeneratingListener {
 
         if (wasSuccessful) {
             logEnter("testRunSuccessful", elapsedTime, Thread.currentThread().getName());
-            deviceTestResult.addNewTimeTag("testRunSuccessful", System.currentTimeMillis() - recordingStartTimeMillis);
+            testRun.addNewTimeTag("testRunSuccessful", System.currentTimeMillis() - recordingStartTimeMillis);
         } else {
             String errorMessage = getSummary().getFailures().get(0).getException().getMessage();
             logEnter("testRunFailed", errorMessage);
-            deviceTestResult.addNewTimeTag("testRunFailed", System.currentTimeMillis() - recordingStartTimeMillis);
-            deviceTestResult.setTestErrorMessage(errorMessage);
+            testRun.addNewTimeTag("testRunFailed", System.currentTimeMillis() - recordingStartTimeMillis);
+            testRun.setTestErrorMessage(errorMessage);
             if (errorMessage != null && errorMessage.toLowerCase(Locale.US).contains("process crash")) {
-                if (deviceTestResult.getCrashStack() == null) {
-                    deviceTestResult.setCrashStack(errorMessage);
+                if (testRun.getCrashStack() == null) {
+                    testRun.setCrashStack(errorMessage);
                 }
             }
             if (e.isStarted() && addedFrameCount < 2) {
@@ -140,8 +140,8 @@ public class Junit5Listener extends SummaryGeneratingListener {
             if (alreadyEnd) {
                 return;
             }
-            deviceTestResult.addNewTimeTag("testRunEnded", System.currentTimeMillis() - recordingStartTimeMillis);
-            deviceTestResult.onTestEnded();
+            testRun.addNewTimeTag("testRunEnded", System.currentTimeMillis() - recordingStartTimeMillis);
+            testRun.onTestEnded();
             deviceInfo.setRunningTestName(null);
             releaseResource();
             alreadyEnd = true;
@@ -194,13 +194,13 @@ public class Junit5Listener extends SummaryGeneratingListener {
 
         ongoingTestUnit.setTestedClass(testClassName);
 
-        deviceTestResult.addNewTimeTag(unitIndex + ". " + ongoingTestUnit.getTitle(), System.currentTimeMillis() - recordingStartTimeMillis);
+        testRun.addNewTimeTag(unitIndex + ". " + ongoingTestUnit.getTitle(), System.currentTimeMillis() - recordingStartTimeMillis);
         deviceInfo.setRunningTestName(ongoingTestUnit.getTitle());
 
-        ongoingTestUnit.setDeviceTestResultId(deviceTestResult.getId());
-        ongoingTestUnit.setTestTaskId(deviceTestResult.getTestTaskId());
+        ongoingTestUnit.setDeviceTestResultId(testRun.getId());
+        ongoingTestUnit.setTestTaskId(testRun.getTestTaskId());
 
-        deviceTestResult.addNewTestUnit(ongoingTestUnit);
+        testRun.addNewTestUnit(ongoingTestUnit);
 
         deviceManager.updateScreenshotImageAsyncDelay(deviceInfo, TimeUnit.SECONDS.toMillis(15), (imagePNGFile -> {
             if (imagePNGFile == null) {
@@ -240,12 +240,12 @@ public class Junit5Listener extends SummaryGeneratingListener {
             logEnter("testFailed", testDisplayName, getTrace(throwable));
             ongoingTestUnit.setStack(getTrace(throwable));
             ongoingTestUnit.setStatusCode(AndroidTestUnit.StatusCodes.FAILURE);
-            deviceTestResult.addNewTimeTag(ongoingTestUnit.getTitle() + ".fail", System.currentTimeMillis() - recordingStartTimeMillis);
-            deviceTestResult.oneMoreFailure();
+            testRun.addNewTimeTag(ongoingTestUnit.getTitle() + ".fail", System.currentTimeMillis() - recordingStartTimeMillis);
+            testRun.oneMoreFailure();
         }
         ongoingTestUnit.setEndTimeMillis(System.currentTimeMillis());
         ongoingTestUnit.setRelEndTimeInVideo(ongoingTestUnit.getEndTimeMillis() - recordingStartTimeMillis);
-        deviceTestResult.addNewTimeTag(ongoingTestUnit.getTitle() + ".end", System.currentTimeMillis() - recordingStartTimeMillis);
+        testRun.addNewTimeTag(ongoingTestUnit.getTitle() + ".end", System.currentTimeMillis() - recordingStartTimeMillis);
     }
 
     private void releaseResource() {

--- a/agent/src/main/java/com/microsoft/hydralab/agent/runner/espresso/EspressoRunner.java
+++ b/agent/src/main/java/com/microsoft/hydralab/agent/runner/espresso/EspressoRunner.java
@@ -7,7 +7,7 @@ import com.android.ddmlib.testrunner.InstrumentationResultParser;
 import com.microsoft.hydralab.agent.runner.TestRunner;
 import com.microsoft.hydralab.agent.runner.TestTaskRunCallback;
 import com.microsoft.hydralab.common.entity.common.DeviceInfo;
-import com.microsoft.hydralab.common.entity.common.DeviceTestTask;
+import com.microsoft.hydralab.common.entity.common.TestRun;
 import com.microsoft.hydralab.common.entity.common.TestTask;
 import com.microsoft.hydralab.common.management.DeviceManager;
 import com.microsoft.hydralab.common.util.ADBOperateUtil;
@@ -29,14 +29,14 @@ public class EspressoRunner extends TestRunner {
     }
 
     @Override
-    protected void run(DeviceInfo deviceInfo, TestTask testTask, DeviceTestTask deviceTestTask) throws Exception {
+    protected void run(DeviceInfo deviceInfo, TestTask testTask, TestRun testRun) throws Exception {
         InstrumentationResultParser instrumentationResultParser = null;
-        Logger reportLogger = deviceTestTask.getLogger();
+        Logger reportLogger = testRun.getLogger();
 
         try {
             /** xml report: parse listener */
             reportLogger.info("Start xml report: parse listener");
-            EspressoTestInfoProcessorListener listener = new EspressoTestInfoProcessorListener(deviceManager, adbOperateUtil, deviceInfo, deviceTestTask, testTask.getPkgName());
+            EspressoTestInfoProcessorListener listener = new EspressoTestInfoProcessorListener(deviceManager, adbOperateUtil, deviceInfo, testRun, testTask.getPkgName());
             instrumentationResultParser = new InstrumentationResultParser(testTask.getTestSuite(), Collections.singletonList(listener)) {
                 @Override
                 public boolean isCancelled() {
@@ -58,10 +58,10 @@ public class EspressoRunner extends TestRunner {
 
             /** set paths */
             String absoluteReportPath = listener.getAbsoluteReportPath();
-            deviceTestTask.setTestXmlReportPath(deviceManager.getTestBaseRelPathInUrl(new File(absoluteReportPath)));
+            testRun.setTestXmlReportPath(deviceManager.getTestBaseRelPathInUrl(new File(absoluteReportPath)));
             File gifFile = listener.getGifFile();
             if (gifFile.exists() && gifFile.length() > 0) {
-                deviceTestTask.setTestGifPath(deviceManager.getTestBaseRelPathInUrl(gifFile));
+                testRun.setTestGifPath(deviceManager.getTestBaseRelPathInUrl(gifFile));
             }
 
         } finally {

--- a/agent/src/main/java/com/microsoft/hydralab/agent/runner/espresso/EspressoTestInfoProcessorListener.java
+++ b/agent/src/main/java/com/microsoft/hydralab/agent/runner/espresso/EspressoTestInfoProcessorListener.java
@@ -8,7 +8,7 @@ import cn.hutool.core.lang.Assert;
 import com.android.ddmlib.testrunner.TestIdentifier;
 import com.microsoft.hydralab.common.entity.common.AndroidTestUnit;
 import com.microsoft.hydralab.common.entity.common.DeviceInfo;
-import com.microsoft.hydralab.common.entity.common.DeviceTestTask;
+import com.microsoft.hydralab.common.entity.common.TestRun;
 import com.microsoft.hydralab.common.logger.LogCollector;
 import com.microsoft.hydralab.common.management.DeviceManager;
 import com.microsoft.hydralab.common.screen.ScreenRecorder;
@@ -28,7 +28,7 @@ import java.util.concurrent.TimeUnit;
 public class EspressoTestInfoProcessorListener extends XmlTestRunListener {
 
     private final DeviceInfo deviceInfo;
-    private final DeviceTestTask deviceTestResult;
+    private final TestRun deviceTestResult;
     private final LogCollector adbLogcatCollector;
     private final ScreenRecorder adbDeviceScreenRecorder;
     private final Logger logger;
@@ -45,7 +45,7 @@ public class EspressoTestInfoProcessorListener extends XmlTestRunListener {
     private int pid;
     private int addedFrameCount;
 
-    public EspressoTestInfoProcessorListener(DeviceManager deviceManager, ADBOperateUtil adbOperateUtil, DeviceInfo deviceInfo, DeviceTestTask deviceTestResult, String pkgName) {
+    public EspressoTestInfoProcessorListener(DeviceManager deviceManager, ADBOperateUtil adbOperateUtil, DeviceInfo deviceInfo, TestRun deviceTestResult, String pkgName) {
         this.deviceManager = deviceManager;
         this.adbOperateUtil = adbOperateUtil;
         this.deviceInfo = deviceInfo;
@@ -53,8 +53,8 @@ public class EspressoTestInfoProcessorListener extends XmlTestRunListener {
         this.logger = deviceTestResult.getLogger();
         this.pkgName = pkgName;
         adbLogcatCollector = deviceManager.getLogCollector(deviceInfo, pkgName, deviceTestResult, logger);
-        adbDeviceScreenRecorder = deviceManager.getScreenRecorder(deviceInfo, deviceTestResult.getDeviceTestResultFolder(), logger);
-        setReportDir(deviceTestResult.getDeviceTestResultFolder());
+        adbDeviceScreenRecorder = deviceManager.getScreenRecorder(deviceInfo, deviceTestResult.getTestRunResultFolder(), logger);
+        setReportDir(deviceTestResult.getTestRunResultFolder());
         try {
             setHostName(InetAddress.getLocalHost().getHostName());
         } catch (UnknownHostException ex) {
@@ -101,7 +101,7 @@ public class EspressoTestInfoProcessorListener extends XmlTestRunListener {
             exception.printStackTrace();
         }
         logger.info("Start gif frames collection");
-        gifFile = new File(deviceTestResult.getDeviceTestResultFolder(), runName + ".gif");
+        gifFile = new File(deviceTestResult.getTestRunResultFolder(), runName + ".gif");
         e.start(gifFile.getAbsolutePath());
         e.setDelay(1000);
         e.setRepeat(0);

--- a/agent/src/main/java/com/microsoft/hydralab/agent/runner/espresso/EspressoTestInfoProcessorListener.java
+++ b/agent/src/main/java/com/microsoft/hydralab/agent/runner/espresso/EspressoTestInfoProcessorListener.java
@@ -28,7 +28,7 @@ import java.util.concurrent.TimeUnit;
 public class EspressoTestInfoProcessorListener extends XmlTestRunListener {
 
     private final DeviceInfo deviceInfo;
-    private final TestRun deviceTestResult;
+    private final TestRun testRun;
     private final LogCollector adbLogcatCollector;
     private final ScreenRecorder adbDeviceScreenRecorder;
     private final Logger logger;
@@ -45,16 +45,16 @@ public class EspressoTestInfoProcessorListener extends XmlTestRunListener {
     private int pid;
     private int addedFrameCount;
 
-    public EspressoTestInfoProcessorListener(DeviceManager deviceManager, ADBOperateUtil adbOperateUtil, DeviceInfo deviceInfo, TestRun deviceTestResult, String pkgName) {
+    public EspressoTestInfoProcessorListener(DeviceManager deviceManager, ADBOperateUtil adbOperateUtil, DeviceInfo deviceInfo, TestRun testRun, String pkgName) {
         this.deviceManager = deviceManager;
         this.adbOperateUtil = adbOperateUtil;
         this.deviceInfo = deviceInfo;
-        this.deviceTestResult = deviceTestResult;
-        this.logger = deviceTestResult.getLogger();
+        this.testRun = testRun;
+        this.logger = testRun.getLogger();
         this.pkgName = pkgName;
-        adbLogcatCollector = deviceManager.getLogCollector(deviceInfo, pkgName, deviceTestResult, logger);
-        adbDeviceScreenRecorder = deviceManager.getScreenRecorder(deviceInfo, deviceTestResult.getResultFolder(), logger);
-        setReportDir(deviceTestResult.getResultFolder());
+        adbLogcatCollector = deviceManager.getLogCollector(deviceInfo, pkgName, testRun, logger);
+        adbDeviceScreenRecorder = deviceManager.getScreenRecorder(deviceInfo, testRun.getResultFolder(), logger);
+        setReportDir(testRun.getResultFolder());
         try {
             setHostName(InetAddress.getLocalHost().getHostName());
         } catch (UnknownHostException ex) {
@@ -69,23 +69,23 @@ public class EspressoTestInfoProcessorListener extends XmlTestRunListener {
     public void startRecording(int maxTime) {
         logger.info("Start adb logcat collection");
         String logcatFilePath = adbLogcatCollector.start();
-        deviceTestResult.setLogcatPath(deviceManager.getTestBaseRelPathInUrl(new File(logcatFilePath)));
+        testRun.setLogcatPath(deviceManager.getTestBaseRelPathInUrl(new File(logcatFilePath)));
         logger.info("Start record screen");
         adbDeviceScreenRecorder.setupDevice();
         adbDeviceScreenRecorder.startRecord(maxTime <= 0 ? 30 * 60 : maxTime);
         recordingStartTimeMillis = System.currentTimeMillis() + adbDeviceScreenRecorder.getPreSleepSeconds() * 1000L;
         final String initializing = "Initializing";
         deviceInfo.setRunningTestName(initializing);
-        deviceTestResult.addNewTimeTag(initializing, 0);
+        testRun.addNewTimeTag(initializing, 0);
     }
 
     @Override
     public void testRunStarted(String runName, int numTests) {
         logEnter("testRunStarted", runName, numTests);
         this.numTests = numTests;
-        deviceTestResult.setTotalCount(numTests);
-        deviceTestResult.setTestStartTimeMillis(System.currentTimeMillis());
-        deviceTestResult.addNewTimeTag("testRunStarted", System.currentTimeMillis() - recordingStartTimeMillis);
+        testRun.setTotalCount(numTests);
+        testRun.setTestStartTimeMillis(System.currentTimeMillis());
+        testRun.addNewTimeTag("testRunStarted", System.currentTimeMillis() - recordingStartTimeMillis);
         deviceInfo.setRunningTestName(runName.substring(runName.lastIndexOf('.') + 1) + ".testRunStarted");
         super.testRunStarted(runName, numTests);
         logEnter(runName, numTests);
@@ -101,7 +101,7 @@ public class EspressoTestInfoProcessorListener extends XmlTestRunListener {
             exception.printStackTrace();
         }
         logger.info("Start gif frames collection");
-        gifFile = new File(deviceTestResult.getResultFolder(), runName + ".gif");
+        gifFile = new File(testRun.getResultFolder(), runName + ".gif");
         e.start(gifFile.getAbsolutePath());
         e.setDelay(1000);
         e.setRepeat(0);
@@ -136,13 +136,13 @@ public class EspressoTestInfoProcessorListener extends XmlTestRunListener {
         }
         ongoingTestUnit.setTestedClass(test.getClassName());
 
-        deviceTestResult.addNewTimeTag(unitIndex + ". " + ongoingTestUnit.getTitle(), System.currentTimeMillis() - recordingStartTimeMillis);
+        testRun.addNewTimeTag(unitIndex + ". " + ongoingTestUnit.getTitle(), System.currentTimeMillis() - recordingStartTimeMillis);
         deviceInfo.setRunningTestName(ongoingTestUnit.getTitle());
 
-        ongoingTestUnit.setDeviceTestResultId(deviceTestResult.getId());
-        ongoingTestUnit.setTestTaskId(deviceTestResult.getTestTaskId());
+        ongoingTestUnit.setDeviceTestResultId(testRun.getId());
+        ongoingTestUnit.setTestTaskId(testRun.getTestTaskId());
 
-        deviceTestResult.addNewTestUnit(ongoingTestUnit);
+        testRun.addNewTestUnit(ongoingTestUnit);
 
         deviceManager.updateScreenshotImageAsyncDelay(deviceInfo, TimeUnit.SECONDS.toMillis(5), (imagePNGFile -> {
             if (imagePNGFile == null) {
@@ -166,8 +166,8 @@ public class EspressoTestInfoProcessorListener extends XmlTestRunListener {
         super.testFailed(test, trace);
         ongoingTestUnit.setStack(trace);
         ongoingTestUnit.setStatusCode(AndroidTestUnit.StatusCodes.FAILURE);
-        deviceTestResult.addNewTimeTag(ongoingTestUnit.getTitle() + ".fail", System.currentTimeMillis() - recordingStartTimeMillis);
-        deviceTestResult.oneMoreFailure();
+        testRun.addNewTimeTag(ongoingTestUnit.getTitle() + ".fail", System.currentTimeMillis() - recordingStartTimeMillis);
+        testRun.oneMoreFailure();
     }
 
     @Override
@@ -175,7 +175,7 @@ public class EspressoTestInfoProcessorListener extends XmlTestRunListener {
         logEnter("testAssumptionFailure", test, trace);
         super.testAssumptionFailure(test, trace);
         ongoingTestUnit.setStack(trace);
-        deviceTestResult.addNewTimeTag(ongoingTestUnit.getTitle() + ".assumptionFail", System.currentTimeMillis() - recordingStartTimeMillis);
+        testRun.addNewTimeTag(ongoingTestUnit.getTitle() + ".assumptionFail", System.currentTimeMillis() - recordingStartTimeMillis);
         ongoingTestUnit.setStatusCode(AndroidTestUnit.StatusCodes.ASSUMPTION_FAILURE);
     }
 
@@ -189,7 +189,7 @@ public class EspressoTestInfoProcessorListener extends XmlTestRunListener {
     @Override
     public void testEnded(TestIdentifier test, Map<String, String> testMetrics) {
         logEnter("testEnded", test, testMetrics);
-        deviceTestResult.addNewTimeTag(ongoingTestUnit.getTitle() + ".end", System.currentTimeMillis() - recordingStartTimeMillis);
+        testRun.addNewTimeTag(ongoingTestUnit.getTitle() + ".end", System.currentTimeMillis() - recordingStartTimeMillis);
         super.testEnded(test, testMetrics);
         if (ongoingTestUnit.getStatusCode() == 0
                 || ongoingTestUnit.getStatusCode() == AndroidTestUnit.StatusCodes.ASSUMPTION_FAILURE
@@ -205,13 +205,13 @@ public class EspressoTestInfoProcessorListener extends XmlTestRunListener {
     @Override
     public void testRunFailed(String errorMessage) {
         logEnter("testRunFailed", errorMessage);
-        deviceTestResult.addNewTimeTag("testRunFailed", System.currentTimeMillis() - recordingStartTimeMillis);
+        testRun.addNewTimeTag("testRunFailed", System.currentTimeMillis() - recordingStartTimeMillis);
         Assert.isTrue(deviceInfo.isAlive(), Const.TaskResult.error_device_offline);
         super.testRunFailed(errorMessage);
-        deviceTestResult.setTestErrorMessage(errorMessage);
+        testRun.setTestErrorMessage(errorMessage);
         if (errorMessage != null && errorMessage.toLowerCase(Locale.US).contains("process crash")) {
-            if (deviceTestResult.getCrashStack() == null) {
-                deviceTestResult.setCrashStack(errorMessage);
+            if (testRun.getCrashStack() == null) {
+                testRun.setCrashStack(errorMessage);
             }
         }
         if (e.isStarted() && addedFrameCount < 2) {
@@ -228,7 +228,7 @@ public class EspressoTestInfoProcessorListener extends XmlTestRunListener {
     @Override
     public void testRunStopped(long elapsedTime) {
         logEnter("testRunStopped", elapsedTime);
-        deviceTestResult.addNewTimeTag("testRunStopped", System.currentTimeMillis() - recordingStartTimeMillis);
+        testRun.addNewTimeTag("testRunStopped", System.currentTimeMillis() - recordingStartTimeMillis);
         super.testRunStopped(elapsedTime);
         // releaseResource();
     }
@@ -240,9 +240,9 @@ public class EspressoTestInfoProcessorListener extends XmlTestRunListener {
             if (alreadyEnd) {
                 return;
             }
-            deviceTestResult.addNewTimeTag("testRunEnded", System.currentTimeMillis() - recordingStartTimeMillis);
+            testRun.addNewTimeTag("testRunEnded", System.currentTimeMillis() - recordingStartTimeMillis);
             super.testRunEnded(elapsedTime, runMetrics);
-            deviceTestResult.onTestEnded();
+            testRun.onTestEnded();
             deviceInfo.setRunningTestName(null);
             releaseResource();
             alreadyEnd = true;

--- a/agent/src/main/java/com/microsoft/hydralab/agent/runner/espresso/EspressoTestInfoProcessorListener.java
+++ b/agent/src/main/java/com/microsoft/hydralab/agent/runner/espresso/EspressoTestInfoProcessorListener.java
@@ -53,8 +53,8 @@ public class EspressoTestInfoProcessorListener extends XmlTestRunListener {
         this.logger = deviceTestResult.getLogger();
         this.pkgName = pkgName;
         adbLogcatCollector = deviceManager.getLogCollector(deviceInfo, pkgName, deviceTestResult, logger);
-        adbDeviceScreenRecorder = deviceManager.getScreenRecorder(deviceInfo, deviceTestResult.getTestRunResultFolder(), logger);
-        setReportDir(deviceTestResult.getTestRunResultFolder());
+        adbDeviceScreenRecorder = deviceManager.getScreenRecorder(deviceInfo, deviceTestResult.getResultFolder(), logger);
+        setReportDir(deviceTestResult.getResultFolder());
         try {
             setHostName(InetAddress.getLocalHost().getHostName());
         } catch (UnknownHostException ex) {
@@ -101,7 +101,7 @@ public class EspressoTestInfoProcessorListener extends XmlTestRunListener {
             exception.printStackTrace();
         }
         logger.info("Start gif frames collection");
-        gifFile = new File(deviceTestResult.getTestRunResultFolder(), runName + ".gif");
+        gifFile = new File(deviceTestResult.getResultFolder(), runName + ".gif");
         e.start(gifFile.getAbsolutePath());
         e.setDelay(1000);
         e.setRepeat(0);

--- a/agent/src/main/java/com/microsoft/hydralab/agent/runner/monkey/AdbMonkeyRunner.java
+++ b/agent/src/main/java/com/microsoft/hydralab/agent/runner/monkey/AdbMonkeyRunner.java
@@ -8,7 +8,7 @@ import com.microsoft.hydralab.agent.runner.TestRunner;
 import com.microsoft.hydralab.agent.runner.TestTaskRunCallback;
 import com.microsoft.hydralab.common.entity.common.AndroidTestUnit;
 import com.microsoft.hydralab.common.entity.common.DeviceInfo;
-import com.microsoft.hydralab.common.entity.common.DeviceTestTask;
+import com.microsoft.hydralab.common.entity.common.TestRun;
 import com.microsoft.hydralab.common.entity.common.TestTask;
 import com.microsoft.hydralab.common.logger.LogCollector;
 import com.microsoft.hydralab.common.logger.MultiLineNoCancelLoggingReceiver;
@@ -45,85 +45,85 @@ public class AdbMonkeyRunner extends TestRunner {
 
 
     @Override
-    protected void run(DeviceInfo deviceInfo, TestTask testTask, DeviceTestTask deviceTestTask) throws Exception {
-        deviceTestTask.setTotalCount(1);
-        Logger reportLogger = deviceTestTask.getLogger();
+    protected void run(DeviceInfo deviceInfo, TestTask testTask, TestRun testRun) throws Exception {
+        testRun.setTotalCount(1);
+        Logger reportLogger = testRun.getLogger();
 
         pkgName = testTask.getPkgName();
         /** start Record **/
-        logCollector = deviceManager.getLogCollector(deviceInfo, pkgName, deviceTestTask, reportLogger);
-        deviceScreenRecorder = deviceManager.getScreenRecorder(deviceInfo, deviceTestTask.getDeviceTestResultFolder(), reportLogger);
-        startRecording(deviceInfo, deviceTestTask, testTask.getTimeOutSecond(), reportLogger);
+        logCollector = deviceManager.getLogCollector(deviceInfo, pkgName, testRun, reportLogger);
+        deviceScreenRecorder = deviceManager.getScreenRecorder(deviceInfo, testRun.getTestRunResultFolder(), reportLogger);
+        startRecording(deviceInfo, testRun, testTask.getTimeOutSecond(), reportLogger);
 
         /** run the test */
         reportLogger.info("Start monkey test");
-        deviceTestTask.setTestStartTimeMillis(System.currentTimeMillis());
+        testRun.setTestStartTimeMillis(System.currentTimeMillis());
         checkTestTaskCancel(testTask);
-        long checkTime = runMonkeyTestOnce(deviceInfo, deviceTestTask, reportLogger, testTask.getInstrumentationArgs(), testTask.getMaxStepCount());
+        long checkTime = runMonkeyTestOnce(deviceInfo, testRun, reportLogger, testTask.getInstrumentationArgs(), testTask.getMaxStepCount());
         if (checkTime > 0) {
-            String crashStack = deviceTestTask.getCrashStack();
+            String crashStack = testRun.getCrashStack();
             if (crashStack != null && !"".equals(crashStack)) {
                 ongoingMonkeyTest.setStatusCode(AndroidTestUnit.StatusCodes.FAILURE);
                 ongoingMonkeyTest.setSuccess(false);
                 ongoingMonkeyTest.setStack(crashStack);
-                deviceTestTask.addNewTimeTagBeforeLast(ongoingMonkeyTest.getTitle() + ".fail", checkTime);
-                deviceTestTask.oneMoreFailure();
+                testRun.addNewTimeTagBeforeLast(ongoingMonkeyTest.getTitle() + ".fail", checkTime);
+                testRun.oneMoreFailure();
             }
         }
-        testRunEnded(deviceInfo, deviceTestTask);
+        testRunEnded(deviceInfo, testRun);
 
         /** set paths */
-        String absoluteReportPath = deviceTestTask.getDeviceTestResultFolder().getAbsolutePath();
-        deviceTestTask.setTestXmlReportPath(deviceManager.getTestBaseRelPathInUrl(new File(absoluteReportPath)));
+        String absoluteReportPath = testRun.getTestRunResultFolder().getAbsolutePath();
+        testRun.setTestXmlReportPath(deviceManager.getTestBaseRelPathInUrl(new File(absoluteReportPath)));
         File gifFile = getGifFile();
         if (gifFile.exists() && gifFile.length() > 0) {
-            deviceTestTask.setTestGifPath(deviceManager.getTestBaseRelPathInUrl(gifFile));
+            testRun.setTestGifPath(deviceManager.getTestBaseRelPathInUrl(gifFile));
         }
 
     }
 
 
-    public void startRecording(DeviceInfo deviceInfo, DeviceTestTask deviceTestTask, int maxTime, Logger logger) {
-        startTools(deviceTestTask, logger);
+    public void startRecording(DeviceInfo deviceInfo, TestRun testRun, int maxTime, Logger logger) {
+        startTools(testRun, logger);
         logger.info("Start record screen");
         deviceScreenRecorder.setupDevice();
         deviceScreenRecorder.startRecord(maxTime <= 0 ? 30 * 60 : maxTime);
         recordingStartTimeMillis = System.currentTimeMillis();
         final String initializing = "Initializing";
         deviceInfo.setRunningTestName(initializing);
-        deviceTestTask.addNewTimeTag(initializing, 0);
+        testRun.addNewTimeTag(initializing, 0);
     }
 
-    private void startTools(DeviceTestTask deviceTestTask, Logger logger) {
+    private void startTools(TestRun testRun, Logger logger) {
         logger.info("Start gif frames collection");
-        gifFile = new File(deviceTestTask.getDeviceTestResultFolder(), pkgName + ".gif");
+        gifFile = new File(testRun.getTestRunResultFolder(), pkgName + ".gif");
         e.start(gifFile.getAbsolutePath());
         e.setDelay(1000);
         e.setRepeat(0);
 
         logger.info("Start adb logcat collection");
         String logcatFilePath = logCollector.start();
-        deviceTestTask.setLogcatPath(deviceManager.getTestBaseRelPathInUrl(new File(logcatFilePath)));
+        testRun.setLogcatPath(deviceManager.getTestBaseRelPathInUrl(new File(logcatFilePath)));
     }
 
     public File getGifFile() {
         return gifFile;
     }
 
-    public long runMonkeyTestOnce(DeviceInfo deviceInfo, DeviceTestTask deviceTestTask, Logger logger, Map<String, String> instrumentationArgs, int maxStepCount) {
+    public long runMonkeyTestOnce(DeviceInfo deviceInfo, TestRun testRun, Logger logger, Map<String, String> instrumentationArgs, int maxStepCount) {
         long checkTime = 0;
         final int unitIndex = ++index;
         String title = "Monkey_Test";
 
         ongoingMonkeyTest = new AndroidTestUnit();
-        ongoingMonkeyTest.setNumtests(deviceTestTask.getTotalCount());
+        ongoingMonkeyTest.setNumtests(testRun.getTotalCount());
         ongoingMonkeyTest.setStartTimeMillis(System.currentTimeMillis());
         ongoingMonkeyTest.setRelStartTimeInVideo(ongoingMonkeyTest.getStartTimeMillis() - recordingStartTimeMillis);
         ongoingMonkeyTest.setCurrentIndexNum(unitIndex);
         ongoingMonkeyTest.setTestName(title);
         ongoingMonkeyTest.setTestedClass(pkgName);
-        ongoingMonkeyTest.setDeviceTestResultId(deviceTestTask.getId());
-        ongoingMonkeyTest.setTestTaskId(deviceTestTask.getTestTaskId());
+        ongoingMonkeyTest.setDeviceTestResultId(testRun.getId());
+        ongoingMonkeyTest.setTestTaskId(testRun.getTestTaskId());
 
         logger.info(ongoingMonkeyTest.getTitle());
         deviceManager.updateScreenshotImageAsyncDelay(deviceInfo, TimeUnit.SECONDS.toMillis(5), (imagePNGFile -> {
@@ -140,7 +140,7 @@ public class AdbMonkeyRunner extends TestRunner {
             }
         }), logger);
         //run monkey test
-        deviceTestTask.addNewTimeTag(unitIndex + ". " + ongoingMonkeyTest.getTitle(), System.currentTimeMillis() - recordingStartTimeMillis);
+        testRun.addNewTimeTag(unitIndex + ". " + ongoingMonkeyTest.getTitle(), System.currentTimeMillis() - recordingStartTimeMillis);
         deviceInfo.setRunningTestName(ongoingMonkeyTest.getTitle());
         StringBuilder argString = new StringBuilder();
         if (instrumentationArgs != null && !instrumentationArgs.isEmpty()) {
@@ -166,22 +166,22 @@ public class AdbMonkeyRunner extends TestRunner {
             ongoingMonkeyTest.setStatusCode(AndroidTestUnit.StatusCodes.FAILURE);
             ongoingMonkeyTest.setSuccess(false);
             ongoingMonkeyTest.setStack(e.toString());
-            deviceTestTask.setSuccess(false);
-            deviceTestTask.addNewTimeTagBeforeLast(ongoingMonkeyTest.getTitle() + ".fail", System.currentTimeMillis() - recordingStartTimeMillis);
-            deviceTestTask.oneMoreFailure();
+            testRun.setSuccess(false);
+            testRun.addNewTimeTagBeforeLast(ongoingMonkeyTest.getTitle() + ".fail", System.currentTimeMillis() - recordingStartTimeMillis);
+            testRun.oneMoreFailure();
         }
 
         logger.info(ongoingMonkeyTest.getTitle() + ".end");
         ongoingMonkeyTest.setEndTimeMillis(System.currentTimeMillis());
         deviceInfo.setRunningTestName(null);
-        deviceTestTask.addNewTestUnit(ongoingMonkeyTest);
-        deviceTestTask.addNewTimeTag(ongoingMonkeyTest.getTitle() + ".end", System.currentTimeMillis() - recordingStartTimeMillis);
+        testRun.addNewTestUnit(ongoingMonkeyTest);
+        testRun.addNewTimeTag(ongoingMonkeyTest.getTitle() + ".end", System.currentTimeMillis() - recordingStartTimeMillis);
         return checkTime;
     }
 
-    public void testRunEnded(DeviceInfo deviceInfo, DeviceTestTask deviceTestTask) {
-        deviceTestTask.addNewTimeTag("testRunEnded", System.currentTimeMillis() - recordingStartTimeMillis);
-        deviceTestTask.onTestEnded();
+    public void testRunEnded(DeviceInfo deviceInfo, TestRun testRun) {
+        testRun.addNewTimeTag("testRunEnded", System.currentTimeMillis() - recordingStartTimeMillis);
+        testRun.onTestEnded();
         deviceInfo.setRunningTestName(null);
         releaseResource();
     }

--- a/agent/src/main/java/com/microsoft/hydralab/agent/runner/monkey/AdbMonkeyRunner.java
+++ b/agent/src/main/java/com/microsoft/hydralab/agent/runner/monkey/AdbMonkeyRunner.java
@@ -52,7 +52,7 @@ public class AdbMonkeyRunner extends TestRunner {
         pkgName = testTask.getPkgName();
         /** start Record **/
         logCollector = deviceManager.getLogCollector(deviceInfo, pkgName, testRun, reportLogger);
-        deviceScreenRecorder = deviceManager.getScreenRecorder(deviceInfo, testRun.getTestRunResultFolder(), reportLogger);
+        deviceScreenRecorder = deviceManager.getScreenRecorder(deviceInfo, testRun.getResultFolder(), reportLogger);
         startRecording(deviceInfo, testRun, testTask.getTimeOutSecond(), reportLogger);
 
         /** run the test */
@@ -73,7 +73,7 @@ public class AdbMonkeyRunner extends TestRunner {
         testRunEnded(deviceInfo, testRun);
 
         /** set paths */
-        String absoluteReportPath = testRun.getTestRunResultFolder().getAbsolutePath();
+        String absoluteReportPath = testRun.getResultFolder().getAbsolutePath();
         testRun.setTestXmlReportPath(deviceManager.getTestBaseRelPathInUrl(new File(absoluteReportPath)));
         File gifFile = getGifFile();
         if (gifFile.exists() && gifFile.length() > 0) {
@@ -96,7 +96,7 @@ public class AdbMonkeyRunner extends TestRunner {
 
     private void startTools(TestRun testRun, Logger logger) {
         logger.info("Start gif frames collection");
-        gifFile = new File(testRun.getTestRunResultFolder(), pkgName + ".gif");
+        gifFile = new File(testRun.getResultFolder(), pkgName + ".gif");
         e.start(gifFile.getAbsolutePath());
         e.setDelay(1000);
         e.setRepeat(0);

--- a/agent/src/main/java/com/microsoft/hydralab/agent/runner/monkey/AppiumMonkeyRunner.java
+++ b/agent/src/main/java/com/microsoft/hydralab/agent/runner/monkey/AppiumMonkeyRunner.java
@@ -54,7 +54,7 @@ public class AppiumMonkeyRunner extends AppiumRunner {
 
         testRun.addNewTimeTag(1 + ". " + ongoingMonkeyTest.getTitle(), System.currentTimeMillis() - recordingStartTimeMillis);
         deviceInfo.setRunningTestName(ongoingMonkeyTest.getTitle());
-        File gifFile = new File(testRun.getTestRunResultFolder(), pkgName + ".gif");
+        File gifFile = new File(testRun.getResultFolder(), pkgName + ".gif");
         e.start(gifFile.getAbsolutePath());
         e.setDelay(1000);
         e.setRepeat(0);

--- a/agent/src/main/java/com/microsoft/hydralab/agent/runner/monkey/AppiumMonkeyRunner.java
+++ b/agent/src/main/java/com/microsoft/hydralab/agent/runner/monkey/AppiumMonkeyRunner.java
@@ -8,7 +8,7 @@ import com.microsoft.hydralab.agent.runner.TestTaskRunCallback;
 import com.microsoft.hydralab.agent.runner.appium.AppiumRunner;
 import com.microsoft.hydralab.common.entity.common.AndroidTestUnit;
 import com.microsoft.hydralab.common.entity.common.DeviceInfo;
-import com.microsoft.hydralab.common.entity.common.DeviceTestTask;
+import com.microsoft.hydralab.common.entity.common.TestRun;
 import com.microsoft.hydralab.common.entity.common.TestTask;
 import com.microsoft.hydralab.common.logger.LogCollector;
 import com.microsoft.hydralab.common.management.DeviceManager;
@@ -28,7 +28,7 @@ public class AppiumMonkeyRunner extends AppiumRunner {
     }
 
     @Override
-    protected File runAndGetGif(File appiumJarFile, String appiumCommand, DeviceInfo deviceInfo, TestTask testTask, DeviceTestTask deviceTestTask, File deviceTestResultFolder, Logger reportLogger) {
+    protected File runAndGetGif(File appiumJarFile, String appiumCommand, DeviceInfo deviceInfo, TestTask testTask, TestRun testRun, File deviceTestResultFolder, Logger reportLogger) {
         String pkgName = testTask.getPkgName();
 
         long recordingStartTimeMillis = System.currentTimeMillis();
@@ -36,25 +36,25 @@ public class AppiumMonkeyRunner extends AppiumRunner {
         deviceScreenRecorder.setupDevice();
         deviceScreenRecorder.startRecord(testTask.getTimeOutSecond());
 
-        LogCollector logCollector = deviceManager.getLogCollector(deviceInfo, pkgName, deviceTestTask, reportLogger);
+        LogCollector logCollector = deviceManager.getLogCollector(deviceInfo, pkgName, testRun, reportLogger);
         logCollector.start();
-        deviceTestTask.setTotalCount(1);
+        testRun.setTotalCount(1);
 
         AndroidTestUnit ongoingMonkeyTest = new AndroidTestUnit();
-        ongoingMonkeyTest.setNumtests(deviceTestTask.getTotalCount());
+        ongoingMonkeyTest.setNumtests(testRun.getTotalCount());
         ongoingMonkeyTest.setStartTimeMillis(System.currentTimeMillis());
         ongoingMonkeyTest.setRelStartTimeInVideo(ongoingMonkeyTest.getStartTimeMillis() - recordingStartTimeMillis);
         ongoingMonkeyTest.setCurrentIndexNum(1);
         ongoingMonkeyTest.setTestName("Appium_Monkey_Test");
         ongoingMonkeyTest.setTestedClass(pkgName);
-        ongoingMonkeyTest.setDeviceTestResultId(deviceTestTask.getId());
-        ongoingMonkeyTest.setTestTaskId(deviceTestTask.getTestTaskId());
+        ongoingMonkeyTest.setDeviceTestResultId(testRun.getId());
+        ongoingMonkeyTest.setTestTaskId(testRun.getTestTaskId());
 
         reportLogger.info(ongoingMonkeyTest.getTitle());
 
-        deviceTestTask.addNewTimeTag(1 + ". " + ongoingMonkeyTest.getTitle(), System.currentTimeMillis() - recordingStartTimeMillis);
+        testRun.addNewTimeTag(1 + ". " + ongoingMonkeyTest.getTitle(), System.currentTimeMillis() - recordingStartTimeMillis);
         deviceInfo.setRunningTestName(ongoingMonkeyTest.getTitle());
-        File gifFile = new File(deviceTestTask.getDeviceTestResultFolder(), pkgName + ".gif");
+        File gifFile = new File(testRun.getTestRunResultFolder(), pkgName + ".gif");
         e.start(gifFile.getAbsolutePath());
         e.setDelay(1000);
         e.setRepeat(0);
@@ -71,7 +71,7 @@ public class AppiumMonkeyRunner extends AppiumRunner {
                 ioException.printStackTrace();
             }
         }), reportLogger);
-        deviceTestTask.setTestStartTimeMillis(System.currentTimeMillis());
+        testRun.setTestStartTimeMillis(System.currentTimeMillis());
         deviceManager.runAppiumMonkey(deviceInfo, pkgName, testTask.getMaxStepCount(), reportLogger);
 
         deviceScreenRecorder.finishRecording();
@@ -83,23 +83,23 @@ public class AppiumMonkeyRunner extends AppiumRunner {
             ongoingMonkeyTest.setStatusCode(AndroidTestUnit.StatusCodes.FAILURE);
             ongoingMonkeyTest.setSuccess(false);
             ongoingMonkeyTest.setStack(e.toString());
-            deviceTestTask.setSuccess(false);
-            deviceTestTask.addNewTimeTagBeforeLast(ongoingMonkeyTest.getTitle() + ".fail", System.currentTimeMillis() - recordingStartTimeMillis);
-            deviceTestTask.oneMoreFailure();
+            testRun.setSuccess(false);
+            testRun.addNewTimeTagBeforeLast(ongoingMonkeyTest.getTitle() + ".fail", System.currentTimeMillis() - recordingStartTimeMillis);
+            testRun.oneMoreFailure();
         } else {
             // Pass
             ongoingMonkeyTest.setStatusCode(AndroidTestUnit.StatusCodes.OK);
             ongoingMonkeyTest.setSuccess(true);
-            deviceTestTask.setSuccess(true);
+            testRun.setSuccess(true);
         }
 
         // Test finish
         reportLogger.info(ongoingMonkeyTest.getTitle() + ".end");
         ongoingMonkeyTest.setEndTimeMillis(System.currentTimeMillis());
         deviceInfo.setRunningTestName(null);
-        deviceTestTask.addNewTestUnit(ongoingMonkeyTest);
-        deviceTestTask.addNewTimeTag(ongoingMonkeyTest.getTitle() + ".end", System.currentTimeMillis() - recordingStartTimeMillis);
-        deviceTestTask.onTestEnded();
+        testRun.addNewTestUnit(ongoingMonkeyTest);
+        testRun.addNewTimeTag(ongoingMonkeyTest.getTitle() + ".end", System.currentTimeMillis() - recordingStartTimeMillis);
+        testRun.onTestEnded();
         return gifFile;
     }
 }

--- a/agent/src/main/java/com/microsoft/hydralab/agent/runner/smart/SmartRunner.java
+++ b/agent/src/main/java/com/microsoft/hydralab/agent/runner/smart/SmartRunner.java
@@ -12,7 +12,7 @@ import com.microsoft.hydralab.agent.runner.TestTaskRunCallback;
 import com.microsoft.hydralab.common.entity.agent.SmartTestParam;
 import com.microsoft.hydralab.common.entity.common.AndroidTestUnit;
 import com.microsoft.hydralab.common.entity.common.DeviceInfo;
-import com.microsoft.hydralab.common.entity.common.DeviceTestTask;
+import com.microsoft.hydralab.common.entity.common.TestRun;
 import com.microsoft.hydralab.common.entity.common.TestTask;
 import com.microsoft.hydralab.common.logger.LogCollector;
 import com.microsoft.hydralab.common.management.DeviceManager;
@@ -42,22 +42,22 @@ public class SmartRunner extends TestRunner {
     }
 
     @Override
-    protected void run(DeviceInfo deviceInfo, TestTask testTask, DeviceTestTask deviceTestTask) throws Exception {
+    protected void run(DeviceInfo deviceInfo, TestTask testTask, TestRun testRun) throws Exception {
 
-        deviceTestTask.setTotalCount(testTask.getDeviceTestCount());
-        Logger reportLogger = deviceTestTask.getLogger();
+        testRun.setTotalCount(testTask.getDeviceTestCount());
+        Logger reportLogger = testRun.getLogger();
 
         pkgName = testTask.getPkgName();
 
         /** start Record **/
-        logCollector = deviceManager.getLogCollector(deviceInfo, pkgName, deviceTestTask, reportLogger);
-        deviceScreenRecorder = deviceManager.getScreenRecorder(deviceInfo, deviceTestTask.getDeviceTestResultFolder(), reportLogger);
-        startRecording(deviceInfo, deviceTestTask, testTask.getTimeOutSecond(), reportLogger);
+        logCollector = deviceManager.getLogCollector(deviceInfo, pkgName, testRun, reportLogger);
+        deviceScreenRecorder = deviceManager.getScreenRecorder(deviceInfo, testRun.getTestRunResultFolder(), reportLogger);
+        startRecording(deviceInfo, testRun, testTask.getTimeOutSecond(), reportLogger);
 
         /** run the test */
         reportLogger.info("Start Smart test");
         checkTestTaskCancel(testTask);
-        deviceTestTask.setTestStartTimeMillis(System.currentTimeMillis());
+        testRun.setTestStartTimeMillis(System.currentTimeMillis());
 
         /** init smart_test arg */
         //TODO choose model before starting test task
@@ -65,62 +65,62 @@ public class SmartRunner extends TestRunner {
 
         for (int i = 1; i <= testTask.getDeviceTestCount(); i++) {
             checkTestTaskCancel(testTask);
-            runSmartTestOnce(i, deviceInfo, deviceTestTask, reportLogger);
+            runSmartTestOnce(i, deviceInfo, testRun, reportLogger);
         }
-        testRunEnded(deviceInfo, deviceTestTask);
+        testRunEnded(deviceInfo, testRun);
         /** set paths */
-        String absoluteReportPath = deviceTestTask.getDeviceTestResultFolder().getAbsolutePath();
-        deviceTestTask.setTestXmlReportPath(deviceManager.getTestBaseRelPathInUrl(new File(absoluteReportPath)));
+        String absoluteReportPath = testRun.getTestRunResultFolder().getAbsolutePath();
+        testRun.setTestXmlReportPath(deviceManager.getTestBaseRelPathInUrl(new File(absoluteReportPath)));
         File gifFile = getGifFile();
         if (gifFile.exists() && gifFile.length() > 0) {
-            deviceTestTask.setTestGifPath(deviceManager.getTestBaseRelPathInUrl(gifFile));
+            testRun.setTestGifPath(deviceManager.getTestBaseRelPathInUrl(gifFile));
         }
 
     }
 
-    public void startRecording(DeviceInfo deviceInfo, DeviceTestTask deviceTestTask, int maxTime, Logger logger) {
-        startTools(deviceTestTask, logger);
+    public void startRecording(DeviceInfo deviceInfo, TestRun testRun, int maxTime, Logger logger) {
+        startTools(testRun, logger);
         logger.info("Start record screen");
         deviceScreenRecorder.setupDevice();
         deviceScreenRecorder.startRecord(maxTime <= 0 ? 30 * 60 : maxTime);
         recordingStartTimeMillis = System.currentTimeMillis();
         final String initializing = "Initializing";
         deviceInfo.setRunningTestName(initializing);
-        deviceTestTask.addNewTimeTag(initializing, 0);
+        testRun.addNewTimeTag(initializing, 0);
     }
 
-    private void startTools(DeviceTestTask deviceTestTask, Logger logger) {
+    private void startTools(TestRun testRun, Logger logger) {
         logger.info("Start gif frames collection");
-        gifFile = new File(deviceTestTask.getDeviceTestResultFolder(), pkgName + ".gif");
+        gifFile = new File(testRun.getTestRunResultFolder(), pkgName + ".gif");
         e.start(gifFile.getAbsolutePath());
         e.setDelay(1000);
         e.setRepeat(0);
 
         logger.info("Start adb logcat collection");
         String logcatFilePath = logCollector.start();
-        deviceTestTask.setLogcatPath(deviceManager.getTestBaseRelPathInUrl(new File(logcatFilePath)));
+        testRun.setLogcatPath(deviceManager.getTestBaseRelPathInUrl(new File(logcatFilePath)));
     }
 
     public File getGifFile() {
         return gifFile;
     }
 
-    public void runSmartTestOnce(int i, DeviceInfo deviceInfo, DeviceTestTask deviceTestTask, Logger logger) {
+    public void runSmartTestOnce(int i, DeviceInfo deviceInfo, TestRun testRun, Logger logger) {
         final int unitIndex = ++index;
         String title = "Smart_Test(" + i + ")";
 
         AndroidTestUnit ongoingSmartTest = new AndroidTestUnit();
 
-        ongoingSmartTest.setNumtests(deviceTestTask.getTotalCount());
+        ongoingSmartTest.setNumtests(testRun.getTotalCount());
         ongoingSmartTest.setStartTimeMillis(System.currentTimeMillis());
         ongoingSmartTest.setRelStartTimeInVideo(ongoingSmartTest.getStartTimeMillis() - recordingStartTimeMillis);
         ongoingSmartTest.setCurrentIndexNum(unitIndex);
         ongoingSmartTest.setTestName(title);
         ongoingSmartTest.setTestedClass(pkgName);
-        ongoingSmartTest.setDeviceTestResultId(deviceTestTask.getId());
-        ongoingSmartTest.setTestTaskId(deviceTestTask.getTestTaskId());
+        ongoingSmartTest.setDeviceTestResultId(testRun.getId());
+        ongoingSmartTest.setTestTaskId(testRun.getTestTaskId());
 
-        deviceTestTask.addNewTimeTag(unitIndex + ". " + ongoingSmartTest.getTitle(), System.currentTimeMillis() - recordingStartTimeMillis);
+        testRun.addNewTimeTag(unitIndex + ". " + ongoingSmartTest.getTitle(), System.currentTimeMillis() - recordingStartTimeMillis);
         deviceInfo.setRunningTestName(ongoingSmartTest.getTitle());
         logger.info(ongoingSmartTest.getTitle());
         deviceManager.updateScreenshotImageAsyncDelay(deviceInfo, TimeUnit.SECONDS.toMillis(1), (imagePNGFile -> {
@@ -154,14 +154,14 @@ public class SmartRunner extends TestRunner {
             ongoingSmartTest.setStatusCode(AndroidTestUnit.StatusCodes.FAILURE);
             ongoingSmartTest.setSuccess(false);
             ongoingSmartTest.setStack(res.getString(Const.SmartTestConfig.taskExpTag));
-            deviceTestTask.addNewTimeTag(ongoingSmartTest.getTitle() + ".fail", System.currentTimeMillis() - recordingStartTimeMillis);
-            deviceTestTask.oneMoreFailure();
+            testRun.addNewTimeTag(ongoingSmartTest.getTitle() + ".fail", System.currentTimeMillis() - recordingStartTimeMillis);
+            testRun.oneMoreFailure();
         } else if (crashStack != null && crashStack.size() > 0) {
             ongoingSmartTest.setStatusCode(AndroidTestUnit.StatusCodes.FAILURE);
             ongoingSmartTest.setSuccess(false);
             ongoingSmartTest.setStack(crashStack.toJSONString());
-            deviceTestTask.addNewTimeTag(ongoingSmartTest.getTitle() + ".fail", System.currentTimeMillis() - recordingStartTimeMillis);
-            deviceTestTask.oneMoreFailure();
+            testRun.addNewTimeTag(ongoingSmartTest.getTitle() + ".fail", System.currentTimeMillis() - recordingStartTimeMillis);
+            testRun.oneMoreFailure();
         } else {
             analysisRes = smartTestUtil.analysisRes(res);
             ongoingSmartTest.setStatusCode(AndroidTestUnit.StatusCodes.OK);
@@ -170,18 +170,18 @@ public class SmartRunner extends TestRunner {
         ongoingSmartTest.setEndTimeMillis(System.currentTimeMillis());
         logger.info(ongoingSmartTest.getTitle() + ".end");
         deviceInfo.setRunningTestName(null);
-        deviceTestTask.addNewTestUnit(ongoingSmartTest);
-        deviceTestTask.addNewTimeTag(ongoingSmartTest.getTitle() + ".end", System.currentTimeMillis() - recordingStartTimeMillis);
+        testRun.addNewTestUnit(ongoingSmartTest);
+        testRun.addNewTimeTag(ongoingSmartTest.getTitle() + ".end", System.currentTimeMillis() - recordingStartTimeMillis);
         if (ongoingSmartTest.isSuccess()) {
-            deviceTestTask.addNewTimeTag(ongoingSmartTest.getTitle() + ".res" + ":" + analysisRes, System.currentTimeMillis() - recordingStartTimeMillis);
+            testRun.addNewTimeTag(ongoingSmartTest.getTitle() + ".res" + ":" + analysisRes, System.currentTimeMillis() - recordingStartTimeMillis);
         }
 
     }
 
-    public void testRunEnded(DeviceInfo deviceInfo, DeviceTestTask deviceTestTask) {
+    public void testRunEnded(DeviceInfo deviceInfo, TestRun testRun) {
 
-        deviceTestTask.addNewTimeTag("testRunEnded", System.currentTimeMillis() - recordingStartTimeMillis);
-        deviceTestTask.onTestEnded();
+        testRun.addNewTimeTag("testRunEnded", System.currentTimeMillis() - recordingStartTimeMillis);
+        testRun.onTestEnded();
         deviceInfo.setRunningTestName(null);
         releaseResource();
     }

--- a/agent/src/main/java/com/microsoft/hydralab/agent/runner/smart/SmartRunner.java
+++ b/agent/src/main/java/com/microsoft/hydralab/agent/runner/smart/SmartRunner.java
@@ -51,7 +51,7 @@ public class SmartRunner extends TestRunner {
 
         /** start Record **/
         logCollector = deviceManager.getLogCollector(deviceInfo, pkgName, testRun, reportLogger);
-        deviceScreenRecorder = deviceManager.getScreenRecorder(deviceInfo, testRun.getTestRunResultFolder(), reportLogger);
+        deviceScreenRecorder = deviceManager.getScreenRecorder(deviceInfo, testRun.getResultFolder(), reportLogger);
         startRecording(deviceInfo, testRun, testTask.getTimeOutSecond(), reportLogger);
 
         /** run the test */
@@ -69,7 +69,7 @@ public class SmartRunner extends TestRunner {
         }
         testRunEnded(deviceInfo, testRun);
         /** set paths */
-        String absoluteReportPath = testRun.getTestRunResultFolder().getAbsolutePath();
+        String absoluteReportPath = testRun.getResultFolder().getAbsolutePath();
         testRun.setTestXmlReportPath(deviceManager.getTestBaseRelPathInUrl(new File(absoluteReportPath)));
         File gifFile = getGifFile();
         if (gifFile.exists() && gifFile.length() > 0) {
@@ -91,7 +91,7 @@ public class SmartRunner extends TestRunner {
 
     private void startTools(TestRun testRun, Logger logger) {
         logger.info("Start gif frames collection");
-        gifFile = new File(testRun.getTestRunResultFolder(), pkgName + ".gif");
+        gifFile = new File(testRun.getResultFolder(), pkgName + ".gif");
         e.start(gifFile.getAbsolutePath());
         e.setDelay(1000);
         e.setRepeat(0);

--- a/agent/src/main/java/com/microsoft/hydralab/agent/runner/t2c/T2CRunner.java
+++ b/agent/src/main/java/com/microsoft/hydralab/agent/runner/t2c/T2CRunner.java
@@ -54,7 +54,7 @@ public class T2CRunner extends AppiumRunner {
         deviceInfo.setRunningTestName(pkgName.substring(pkgName.lastIndexOf('.') + 1) + ".testRunStarted");
         currentIndex = 0;
 
-        File gifFile = new File(testRun.getTestRunResultFolder(), pkgName + ".gif");
+        File gifFile = new File(testRun.getResultFolder(), pkgName + ".gif");
         e.start(gifFile.getAbsolutePath());
         e.setDelay(1000);
         e.setRepeat(0);

--- a/agent/src/main/java/com/microsoft/hydralab/agent/runner/t2c/T2CRunner.java
+++ b/agent/src/main/java/com/microsoft/hydralab/agent/runner/t2c/T2CRunner.java
@@ -8,7 +8,7 @@ import com.microsoft.hydralab.agent.runner.TestTaskRunCallback;
 import com.microsoft.hydralab.agent.runner.appium.AppiumRunner;
 import com.microsoft.hydralab.common.entity.common.AndroidTestUnit;
 import com.microsoft.hydralab.common.entity.common.DeviceInfo;
-import com.microsoft.hydralab.common.entity.common.DeviceTestTask;
+import com.microsoft.hydralab.common.entity.common.TestRun;
 import com.microsoft.hydralab.common.entity.common.TestTask;
 import com.microsoft.hydralab.common.logger.LogCollector;
 import com.microsoft.hydralab.common.management.DeviceManager;
@@ -36,7 +36,7 @@ public class T2CRunner extends AppiumRunner {
 
     @Override
     protected File runAndGetGif(File initialJsonFile, String unusedSuiteName, DeviceInfo deviceInfo, TestTask testTask,
-                                DeviceTestTask deviceTestTask, File deviceTestResultFolder, Logger reportLogger) {
+                                TestRun testRun, File deviceTestResultFolder, Logger reportLogger) {
         pkgName = testTask.getPkgName();
 
         // Test start
@@ -45,61 +45,61 @@ public class T2CRunner extends AppiumRunner {
         deviceScreenRecorder.startRecord(testTask.getTimeOutSecond());
         long recordingStartTimeMillis = System.currentTimeMillis();
 
-        logCollector = deviceManager.getLogCollector(deviceInfo, pkgName, deviceTestTask, reportLogger);
+        logCollector = deviceManager.getLogCollector(deviceInfo, pkgName, testRun, reportLogger);
         logCollector.start();
 
-        deviceTestTask.setTotalCount(testTask.testJsonFileList.size() + (initialJsonFile == null ? 0 : 1));
-        deviceTestTask.setTestStartTimeMillis(System.currentTimeMillis());
-        deviceTestTask.addNewTimeTag("testRunStarted", System.currentTimeMillis() - recordingStartTimeMillis);
+        testRun.setTotalCount(testTask.testJsonFileList.size() + (initialJsonFile == null ? 0 : 1));
+        testRun.setTestStartTimeMillis(System.currentTimeMillis());
+        testRun.addNewTimeTag("testRunStarted", System.currentTimeMillis() - recordingStartTimeMillis);
         deviceInfo.setRunningTestName(pkgName.substring(pkgName.lastIndexOf('.') + 1) + ".testRunStarted");
         currentIndex = 0;
 
-        File gifFile = new File(deviceTestTask.getDeviceTestResultFolder(), pkgName + ".gif");
+        File gifFile = new File(testRun.getTestRunResultFolder(), pkgName + ".gif");
         e.start(gifFile.getAbsolutePath());
         e.setDelay(1000);
         e.setRepeat(0);
 
         if (initialJsonFile != null) {
-            runT2CJsonTestCase(initialJsonFile, deviceInfo, deviceTestTask, reportLogger, recordingStartTimeMillis);
+            runT2CJsonTestCase(initialJsonFile, deviceInfo, testRun, reportLogger, recordingStartTimeMillis);
         }
         for (File jsonFile : testTask.testJsonFileList) {
-            runT2CJsonTestCase(jsonFile, deviceInfo, deviceTestTask, reportLogger, recordingStartTimeMillis);
+            runT2CJsonTestCase(jsonFile, deviceInfo, testRun, reportLogger, recordingStartTimeMillis);
         }
 
 
         // Test finish
         reportLogger.info(pkgName + ".end");
-        deviceTestTask.addNewTimeTag("testRunEnded", System.currentTimeMillis() - recordingStartTimeMillis);
-        deviceTestTask.onTestEnded();
+        testRun.addNewTimeTag("testRunEnded", System.currentTimeMillis() - recordingStartTimeMillis);
+        testRun.onTestEnded();
         deviceInfo.setRunningTestName(null);
         releaseResource();
         return gifFile;
     }
 
     @Override
-    public DeviceTestTask buildDeviceTestTask(DeviceInfo deviceInfo, TestTask testTask, Logger parentLogger) {
-        DeviceTestTask deviceTestTask = super.buildDeviceTestTask(deviceInfo, testTask, parentLogger);
+    public TestRun createTestRun(DeviceInfo deviceInfo, TestTask testTask, Logger parentLogger) {
+        TestRun testRun = super.createTestRun(deviceInfo, testTask, parentLogger);
         String deviceName = System.getProperties().getProperty("os.name") + "-" + agentName + "-" + deviceInfo.getName();
-        deviceTestTask.setDeviceName(deviceName);
-        return deviceTestTask;
+        testRun.setDeviceName(deviceName);
+        return testRun;
     }
 
-    private void runT2CJsonTestCase(File jsonFile, DeviceInfo deviceInfo, DeviceTestTask deviceTestTask,
+    private void runT2CJsonTestCase(File jsonFile, DeviceInfo deviceInfo, TestRun testRun,
                                     Logger reportLogger, long recordingStartTimeMillis) {
         AndroidTestUnit ongoingTest = new AndroidTestUnit();
-        ongoingTest.setNumtests(deviceTestTask.getTotalCount());
+        ongoingTest.setNumtests(testRun.getTotalCount());
         ongoingTest.setStartTimeMillis(System.currentTimeMillis());
         ongoingTest.setRelStartTimeInVideo(ongoingTest.getStartTimeMillis() - recordingStartTimeMillis);
         ongoingTest.setCurrentIndexNum(currentIndex++);
         ongoingTest.setTestName(jsonFile.getName());
         ongoingTest.setTestedClass(pkgName);
-        ongoingTest.setDeviceTestResultId(deviceTestTask.getId());
-        ongoingTest.setTestTaskId(deviceTestTask.getTestTaskId());
+        ongoingTest.setDeviceTestResultId(testRun.getId());
+        ongoingTest.setTestTaskId(testRun.getTestTaskId());
 
         reportLogger.info(ongoingTest.getTitle());
 
-        deviceTestTask.addNewTimeTag(currentIndex + ". " + ongoingTest.getTitle(), System.currentTimeMillis() - recordingStartTimeMillis);
-        deviceTestTask.addNewTestUnit(ongoingTest);
+        testRun.addNewTimeTag(currentIndex + ". " + ongoingTest.getTitle(), System.currentTimeMillis() - recordingStartTimeMillis);
+        testRun.addNewTestUnit(ongoingTest);
 
         deviceManager.updateScreenshotImageAsyncDelay(deviceInfo, TimeUnit.SECONDS.toMillis(5), (imagePNGFile -> {
             if (imagePNGFile == null) {
@@ -125,12 +125,12 @@ public class T2CRunner extends AppiumRunner {
             ongoingTest.setStatusCode(AndroidTestUnit.StatusCodes.FAILURE);
             ongoingTest.setSuccess(false);
             ongoingTest.setStack(e.toString());
-            deviceTestTask.addNewTimeTag(ongoingTest.getTitle() + ".fail", System.currentTimeMillis() - recordingStartTimeMillis);
-            deviceTestTask.oneMoreFailure();
+            testRun.addNewTimeTag(ongoingTest.getTitle() + ".fail", System.currentTimeMillis() - recordingStartTimeMillis);
+            testRun.oneMoreFailure();
         }
         ongoingTest.setEndTimeMillis(System.currentTimeMillis());
         ongoingTest.setRelEndTimeInVideo(ongoingTest.getEndTimeMillis() - recordingStartTimeMillis);
-        deviceTestTask.addNewTimeTag(ongoingTest.getTitle() + ".end", System.currentTimeMillis() - recordingStartTimeMillis);
+        testRun.addNewTimeTag(ongoingTest.getTitle() + ".end", System.currentTimeMillis() - recordingStartTimeMillis);
     }
 
     private void releaseResource() {

--- a/agent/src/main/java/com/microsoft/hydralab/agent/service/AgentWebSocketClientService.java
+++ b/agent/src/main/java/com/microsoft/hydralab/agent/service/AgentWebSocketClientService.java
@@ -210,7 +210,7 @@ public class AgentWebSocketClientService implements TestTaskRunCallback {
     }
 
     @Override
-    public void onOneDeviceComplete(TestTask testTask, DeviceInfo deviceControl, Logger logger, DeviceTestTask result) {
+    public void onOneDeviceComplete(TestTask testTask, DeviceInfo deviceControl, Logger logger, TestRun result) {
 
     }
 

--- a/agent/src/main/java/com/microsoft/hydralab/agent/service/TestDataService.java
+++ b/agent/src/main/java/com/microsoft/hydralab/agent/service/TestDataService.java
@@ -7,7 +7,7 @@ import com.microsoft.hydralab.common.entity.common.TestRun;
 import com.microsoft.hydralab.common.entity.common.EntityFileRelation;
 import com.microsoft.hydralab.common.entity.common.TestTask;
 import com.microsoft.hydralab.common.repository.AndroidTestUnitRepository;
-import com.microsoft.hydralab.common.repository.DeviceTestResultRepository;
+import com.microsoft.hydralab.common.repository.TestRunRepository;
 import com.microsoft.hydralab.common.repository.KeyValueRepository;
 import com.microsoft.hydralab.common.repository.TestTaskRepository;
 import com.microsoft.hydralab.common.util.AttachmentService;
@@ -27,7 +27,7 @@ public class TestDataService {
     @Resource
     AndroidTestUnitRepository androidTestUnitRepository;
     @Resource
-    DeviceTestResultRepository deviceTestResultRepository;
+    TestRunRepository testRunRepository;
     @Resource
     KeyValueRepository keyValueRepository;
     @Resource
@@ -39,7 +39,7 @@ public class TestDataService {
             return;
         }
 
-        deviceTestResultRepository.saveAll(deviceTestResults);
+        testRunRepository.saveAll(deviceTestResults);
         testTaskRepository.save(testTask);
 
         List<AndroidTestUnit> list = new ArrayList<>();

--- a/agent/src/main/java/com/microsoft/hydralab/agent/service/TestDataService.java
+++ b/agent/src/main/java/com/microsoft/hydralab/agent/service/TestDataService.java
@@ -34,19 +34,19 @@ public class TestDataService {
     AttachmentService attachmentService;
 
     public void saveTestTaskData(TestTask testTask) {
-        List<TestRun> deviceTestResults = testTask.getDeviceTestResults();
-        if (deviceTestResults.isEmpty()) {
+        List<TestRun> testRuns = testTask.getDeviceTestResults();
+        if (testRuns.isEmpty()) {
             return;
         }
 
-        testRunRepository.saveAll(deviceTestResults);
+        testRunRepository.saveAll(testRuns);
         testTaskRepository.save(testTask);
 
         List<AndroidTestUnit> list = new ArrayList<>();
-        for (TestRun deviceTestResult : deviceTestResults) {
-            attachmentService.saveRelations(deviceTestResult.getId(), EntityFileRelation.EntityType.TEST_RESULT, deviceTestResult.getAttachments());
+        for (TestRun testRun : testRuns) {
+            attachmentService.saveRelations(testRun.getId(), EntityFileRelation.EntityType.TEST_RESULT, testRun.getAttachments());
 
-            List<AndroidTestUnit> testUnitList = deviceTestResult.getTestUnitList();
+            List<AndroidTestUnit> testUnitList = testRun.getTestUnitList();
             list.addAll(testUnitList);
 
             // only save failed cases
@@ -58,11 +58,11 @@ public class TestDataService {
                 keyValueRepository.saveAndroidTestUnit(androidTestUnit);
             }
 
-            String crashStack = deviceTestResult.getCrashStack();
+            String crashStack = testRun.getCrashStack();
             if (crashStack == null) {
                 continue;
             }
-            keyValueRepository.saveCrashStack(deviceTestResult.getCrashStackId(), deviceTestResult.getCrashStack());
+            keyValueRepository.saveCrashStack(testRun.getCrashStackId(), testRun.getCrashStack());
         }
         androidTestUnitRepository.saveAll(list);
         LOGGER.info("All saved {}", testTask.getId());

--- a/agent/src/main/java/com/microsoft/hydralab/agent/service/TestDataService.java
+++ b/agent/src/main/java/com/microsoft/hydralab/agent/service/TestDataService.java
@@ -3,7 +3,7 @@
 package com.microsoft.hydralab.agent.service;
 
 import com.microsoft.hydralab.common.entity.common.AndroidTestUnit;
-import com.microsoft.hydralab.common.entity.common.DeviceTestTask;
+import com.microsoft.hydralab.common.entity.common.TestRun;
 import com.microsoft.hydralab.common.entity.common.EntityFileRelation;
 import com.microsoft.hydralab.common.entity.common.TestTask;
 import com.microsoft.hydralab.common.repository.AndroidTestUnitRepository;
@@ -34,7 +34,7 @@ public class TestDataService {
     AttachmentService attachmentService;
 
     public void saveTestTaskData(TestTask testTask) {
-        List<DeviceTestTask> deviceTestResults = testTask.getDeviceTestResults();
+        List<TestRun> deviceTestResults = testTask.getDeviceTestResults();
         if (deviceTestResults.isEmpty()) {
             return;
         }
@@ -43,7 +43,7 @@ public class TestDataService {
         testTaskRepository.save(testTask);
 
         List<AndroidTestUnit> list = new ArrayList<>();
-        for (DeviceTestTask deviceTestResult : deviceTestResults) {
+        for (TestRun deviceTestResult : deviceTestResults) {
             attachmentService.saveRelations(deviceTestResult.getId(), EntityFileRelation.EntityType.TEST_RESULT, deviceTestResult.getAttachments());
 
             List<AndroidTestUnit> testUnitList = deviceTestResult.getTestUnitList();

--- a/agent/src/main/java/com/microsoft/hydralab/agent/service/TestTaskEngineService.java
+++ b/agent/src/main/java/com/microsoft/hydralab/agent/service/TestTaskEngineService.java
@@ -175,10 +175,10 @@ public class TestTaskEngineService implements TestTaskRunCallback {
     }
 
     @Override
-    public void onOneDeviceComplete(TestTask testTask, DeviceInfo deviceControl, Logger logger, DeviceTestTask result) {
+    public void onOneDeviceComplete(TestTask testTask, DeviceInfo deviceControl, Logger logger, TestRun result) {
         log.info("onOneDeviceComplete: {}", deviceControl.getSerialNum());
         deviceControl.finishTask();
-        File deviceTestResultFolder = result.getDeviceTestResultFolder();
+        File deviceTestResultFolder = result.getTestRunResultFolder();
 
         File[] files = deviceTestResultFolder.listFiles();
         List<BlobFileInfo> attachments = new ArrayList<>();
@@ -209,7 +209,7 @@ public class TestTaskEngineService implements TestTaskRunCallback {
         return attachmentService.addFileInfo(blobFileInfo, file, EntityFileRelation.EntityType.TEST_RESULT, logger);
     }
 
-    private void processAndSaveDeviceTestResultBlobUrl(DeviceTestTask result) {
+    private void processAndSaveDeviceTestResultBlobUrl(TestRun result) {
         Assert.isTrue(result.getAttachments().size() > 0, "deviceTestResultBlobUrl should not null");
         String deviceTestResultBlobUrl = result.getAttachments().get(0).getBlobUrl();
         String fileName = result.getAttachments().get(0).getFileName();

--- a/agent/src/main/java/com/microsoft/hydralab/agent/service/TestTaskEngineService.java
+++ b/agent/src/main/java/com/microsoft/hydralab/agent/service/TestTaskEngineService.java
@@ -178,7 +178,7 @@ public class TestTaskEngineService implements TestTaskRunCallback {
     public void onOneDeviceComplete(TestTask testTask, DeviceInfo deviceControl, Logger logger, TestRun result) {
         log.info("onOneDeviceComplete: {}", deviceControl.getSerialNum());
         deviceControl.finishTask();
-        File deviceTestResultFolder = result.getTestRunResultFolder();
+        File deviceTestResultFolder = result.getResultFolder();
 
         File[] files = deviceTestResultFolder.listFiles();
         List<BlobFileInfo> attachments = new ArrayList<>();

--- a/agent/src/test/java/com/microsoft/hydralab/agent/runner/TestRunnerTest.java
+++ b/agent/src/test/java/com/microsoft/hydralab/agent/runner/TestRunnerTest.java
@@ -35,8 +35,8 @@ public class TestRunnerTest extends BaseTest {
 
         TestRun testRun = espressoRunner.createTestRun(deviceInfo, testTask, logger);
 
-        testRun.getLogger().info("Test DeviceTestTask logging function");
-        testRun.getLogger().info("DeviceTestTask InstrumentReportPath {}", testRun.getInstrumentReportPath());
+        testRun.getLogger().info("Test TestRun logging function");
+        testRun.getLogger().info("TestRun InstrumentReportPath {}", testRun.getInstrumentReportPath());
 
         Assertions.assertTrue(new File(testRun.getInstrumentReportPath()).exists());
     }

--- a/agent/src/test/java/com/microsoft/hydralab/agent/runner/TestRunnerTest.java
+++ b/agent/src/test/java/com/microsoft/hydralab/agent/runner/TestRunnerTest.java
@@ -3,7 +3,7 @@ package com.microsoft.hydralab.agent.runner;
 import com.microsoft.hydralab.agent.runner.espresso.EspressoRunner;
 import com.microsoft.hydralab.agent.test.BaseTest;
 import com.microsoft.hydralab.common.entity.common.DeviceInfo;
-import com.microsoft.hydralab.common.entity.common.DeviceTestTask;
+import com.microsoft.hydralab.common.entity.common.TestRun;
 import com.microsoft.hydralab.common.entity.common.TestTask;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -33,11 +33,11 @@ public class TestRunnerTest extends BaseTest {
         testTask.setResourceDir(resourceDir);
         testTask.setTestSuite("TestSuite");
 
-        DeviceTestTask deviceTestTask = espressoRunner.buildDeviceTestTask(deviceInfo, testTask, logger);
+        TestRun testRun = espressoRunner.createTestRun(deviceInfo, testTask, logger);
 
-        deviceTestTask.getLogger().info("Test DeviceTestTask logging function");
-        deviceTestTask.getLogger().info("DeviceTestTask InstrumentReportPath {}", deviceTestTask.getInstrumentReportPath());
+        testRun.getLogger().info("Test DeviceTestTask logging function");
+        testRun.getLogger().info("DeviceTestTask InstrumentReportPath {}", testRun.getInstrumentReportPath());
 
-        Assertions.assertTrue(new File(deviceTestTask.getInstrumentReportPath()).exists());
+        Assertions.assertTrue(new File(testRun.getInstrumentReportPath()).exists());
     }
 }

--- a/center/src/main/java/com/microsoft/hydralab/center/controller/TestDetailController.java
+++ b/center/src/main/java/com/microsoft/hydralab/center/controller/TestDetailController.java
@@ -9,7 +9,7 @@ import com.microsoft.hydralab.center.service.UserTeamManagementService;
 import com.microsoft.hydralab.common.entity.agent.Result;
 import com.microsoft.hydralab.common.entity.center.SysUser;
 import com.microsoft.hydralab.common.entity.common.AndroidTestUnit;
-import com.microsoft.hydralab.common.entity.common.DeviceTestTask;
+import com.microsoft.hydralab.common.entity.common.TestRun;
 import com.microsoft.hydralab.common.repository.KeyValueRepository;
 import com.microsoft.hydralab.common.util.Const;
 import com.microsoft.hydralab.common.util.HydraLabRuntimeException;
@@ -73,7 +73,7 @@ public class TestDetailController {
                 return Result.error(HttpStatus.UNAUTHORIZED.value(), "unauthorized");
             }
 
-            DeviceTestTask testInfo = testDataService.getDeviceTestTaskByCrashId(crashId);
+            TestRun testInfo = testDataService.getDeviceTestTaskByCrashId(crashId);
             testDataService.checkTestDataAuthorization(requestor, testInfo.getTestTaskId());
 
             return Result.ok(keyValueRepository.getCrashStack(crashId));
@@ -103,7 +103,7 @@ public class TestDetailController {
             } else {
                 logger.info("result id {}", resultId); // CodeQL [java/log-injection] False Positive: Has verified the string by regular expression
             }
-            DeviceTestTask testInfo = testDataService.getDeviceTestTaskWithVideoInfo(resultId);
+            TestRun testInfo = testDataService.getDeviceTestTaskWithVideoInfo(resultId);
             testDataService.checkTestDataAuthorization(requestor, testInfo.getTestTaskId());
 
             JSONObject data = new JSONObject();
@@ -148,7 +148,7 @@ public class TestDetailController {
             } else {
                 return Result.error(HttpStatus.INTERNAL_SERVER_ERROR.value(), "Error param! Should be UUID");
             }
-            DeviceTestTask testInfo = testDataService.getDeviceTestTaskWithVideoInfo(deviceTaskId);
+            TestRun testInfo = testDataService.getDeviceTestTaskWithVideoInfo(deviceTaskId);
             testDataService.checkTestDataAuthorization(requestor, testInfo.getTestTaskId());
 
             //use CDN url to access video

--- a/center/src/main/java/com/microsoft/hydralab/center/controller/TestDetailController.java
+++ b/center/src/main/java/com/microsoft/hydralab/center/controller/TestDetailController.java
@@ -73,7 +73,7 @@ public class TestDetailController {
                 return Result.error(HttpStatus.UNAUTHORIZED.value(), "unauthorized");
             }
 
-            TestRun testInfo = testDataService.getDeviceTestTaskByCrashId(crashId);
+            TestRun testInfo = testDataService.getTestRunByCrashId(crashId);
             testDataService.checkTestDataAuthorization(requestor, testInfo.getTestTaskId());
 
             return Result.ok(keyValueRepository.getCrashStack(crashId));
@@ -103,7 +103,7 @@ public class TestDetailController {
             } else {
                 logger.info("result id {}", resultId); // CodeQL [java/log-injection] False Positive: Has verified the string by regular expression
             }
-            TestRun testInfo = testDataService.getDeviceTestTaskWithVideoInfo(resultId);
+            TestRun testInfo = testDataService.getTestRunWithVideoInfo(resultId);
             testDataService.checkTestDataAuthorization(requestor, testInfo.getTestTaskId());
 
             JSONObject data = new JSONObject();
@@ -134,7 +134,7 @@ public class TestDetailController {
     /**
      * Authenticated USER:
      * 1) users with ROLE SUPER_ADMIN/ADMIN,
-     * 2) members of the TEAM that DeviceTestTask is in
+     * 2) members of the TEAM that TestRun is in
      */
     @GetMapping("/api/test/task/device/{deviceTaskId}")
     public Result deviceTaskInfo(@CurrentSecurityContext SysUser requestor,
@@ -148,7 +148,7 @@ public class TestDetailController {
             } else {
                 return Result.error(HttpStatus.INTERNAL_SERVER_ERROR.value(), "Error param! Should be UUID");
             }
-            TestRun testInfo = testDataService.getDeviceTestTaskWithVideoInfo(deviceTaskId);
+            TestRun testInfo = testDataService.getTestRunWithVideoInfo(deviceTaskId);
             testDataService.checkTestDataAuthorization(requestor, testInfo.getTestTaskId());
 
             //use CDN url to access video

--- a/center/src/main/java/com/microsoft/hydralab/center/service/DeviceAgentManagementService.java
+++ b/center/src/main/java/com/microsoft/hydralab/center/service/DeviceAgentManagementService.java
@@ -232,8 +232,8 @@ public class DeviceAgentManagementService {
 
                     //after the task finishing, update the status of device used
                     if (isFinished) {
-                        List<DeviceTestTask> deviceTestResults = testTask.getDeviceTestResults();
-                        for (DeviceTestTask deviceTestResult : deviceTestResults) {
+                        List<TestRun> deviceTestResults = testTask.getDeviceTestResults();
+                        for (TestRun deviceTestResult : deviceTestResults) {
                             updateDeviceStatus(deviceTestResult.getDeviceSerialNumber(), DeviceInfo.ONLINE, null);
                         }
                         //run the task saved in queue

--- a/center/src/main/java/com/microsoft/hydralab/center/service/TestDataService.java
+++ b/center/src/main/java/com/microsoft/hydralab/center/service/TestDataService.java
@@ -8,7 +8,7 @@ import com.microsoft.hydralab.common.entity.center.StabilityData;
 import com.microsoft.hydralab.common.entity.center.SysUser;
 import com.microsoft.hydralab.common.entity.common.*;
 import com.microsoft.hydralab.common.repository.AndroidTestUnitRepository;
-import com.microsoft.hydralab.common.repository.DeviceTestResultRepository;
+import com.microsoft.hydralab.common.repository.TestRunRepository;
 import com.microsoft.hydralab.common.repository.KeyValueRepository;
 import com.microsoft.hydralab.common.repository.TestTaskRepository;
 import com.microsoft.hydralab.common.util.AttachmentService;
@@ -51,7 +51,7 @@ public class TestDataService {
     @Resource
     AndroidTestUnitRepository androidTestUnitRepository;
     @Resource
-    DeviceTestResultRepository deviceTestResultRepository;
+    TestRunRepository testRunRepository;
     @Resource
     KeyValueRepository keyValueRepository;
     @Resource
@@ -69,7 +69,7 @@ public class TestDataService {
         List<AndroidTestUnit> testUnits = androidTestUnitRepository.findBySuccess(false, PageRequest.of(page, size, sortByStartMillis)).getContent();
 
         for (AndroidTestUnit testUnit : testUnits) {
-            Optional<TestRun> deviceTestTask = deviceTestResultRepository.findById(testUnit.getDeviceTestResultId());
+            Optional<TestRun> deviceTestTask = testRunRepository.findById(testUnit.getDeviceTestResultId());
             deviceTestTask.ifPresent(testUnit::setTestRun);
         }
 
@@ -88,7 +88,7 @@ public class TestDataService {
             return null;
         }
         TestTask testTask = taskOpt.get();
-        List<TestRun> byTestTaskId = deviceTestResultRepository.findByTestTaskId(testId);
+        List<TestRun> byTestTaskId = testRunRepository.findByTestTaskId(testId);
 
         if (byTestTaskId == null || byTestTaskId.isEmpty()) {
             return testTask;
@@ -181,7 +181,7 @@ public class TestDataService {
             return testTask;
         }
 
-        deviceTestResultRepository.saveAll(deviceTestResults);
+        testRunRepository.saveAll(deviceTestResults);
 
         List<AndroidTestUnit> list = new ArrayList<>();
         for (TestRun deviceTestResult : deviceTestResults) {
@@ -212,7 +212,7 @@ public class TestDataService {
     }
 
     public TestRun getTestRunWithVideoInfo(String dttId) {
-        TestRun testRun = deviceTestResultRepository.getOne(dttId);
+        TestRun testRun = testRunRepository.getOne(dttId);
         JSONArray deviceTestResInfo = keyValueRepository.getDeviceTestResInfo(dttId);
         testRun.setVideoTimeTagArr(deviceTestResInfo);
         testRun.setVideoBlobUrl();
@@ -221,7 +221,7 @@ public class TestDataService {
     }
 
     public TestRun getTestRunByCrashId(String crashId) {
-        return deviceTestResultRepository.findByCrashStackId(crashId).orElse(null);
+        return testRunRepository.findByCrashStackId(crashId).orElse(null);
     }
 
     public void checkTestDataAuthorization(SysUser requestor, String testId) {

--- a/center/src/main/java/com/microsoft/hydralab/center/service/TestDataService.java
+++ b/center/src/main/java/com/microsoft/hydralab/center/service/TestDataService.java
@@ -70,7 +70,7 @@ public class TestDataService {
 
         for (AndroidTestUnit testUnit : testUnits) {
             Optional<TestRun> deviceTestTask = testRunRepository.findById(testUnit.getDeviceTestResultId());
-            deviceTestTask.ifPresent(testUnit::setTestRun);
+            deviceTestTask.ifPresent(testUnit::setDeviceTestTask);
         }
 
         return testUnits;

--- a/center/src/main/java/com/microsoft/hydralab/center/service/TestDataService.java
+++ b/center/src/main/java/com/microsoft/hydralab/center/service/TestDataService.java
@@ -69,8 +69,8 @@ public class TestDataService {
         List<AndroidTestUnit> testUnits = androidTestUnitRepository.findBySuccess(false, PageRequest.of(page, size, sortByStartMillis)).getContent();
 
         for (AndroidTestUnit testUnit : testUnits) {
-            Optional<DeviceTestTask> deviceTestTask = deviceTestResultRepository.findById(testUnit.getDeviceTestResultId());
-            deviceTestTask.ifPresent(testUnit::setDeviceTestTask);
+            Optional<TestRun> deviceTestTask = deviceTestResultRepository.findById(testUnit.getDeviceTestResultId());
+            deviceTestTask.ifPresent(testUnit::setTestRun);
         }
 
         return testUnits;
@@ -88,14 +88,14 @@ public class TestDataService {
             return null;
         }
         TestTask testTask = taskOpt.get();
-        List<DeviceTestTask> byTestTaskId = deviceTestResultRepository.findByTestTaskId(testId);
+        List<TestRun> byTestTaskId = deviceTestResultRepository.findByTestTaskId(testId);
 
         if (byTestTaskId == null || byTestTaskId.isEmpty()) {
             return testTask;
         }
 
         testTask.getDeviceTestResults().addAll(byTestTaskId);
-        for (DeviceTestTask deviceTestResult : byTestTaskId) {
+        for (TestRun deviceTestResult : byTestTaskId) {
             List<AndroidTestUnit> byDeviceTestResultId = androidTestUnitRepository.findByDeviceTestResultId(deviceTestResult.getId());
             deviceTestResult.getTestUnitList().addAll(byDeviceTestResultId);
             deviceTestResult.setAttachments(attachmentService.getAttachments(deviceTestResult.getId(), EntityFileRelation.EntityType.TEST_RESULT));
@@ -176,7 +176,7 @@ public class TestDataService {
     @CachePut(key = "#testTask.id")
     public TestTask saveTestTaskData(TestTask testTask) {
         testTaskRepository.save(testTask);
-        List<DeviceTestTask> deviceTestResults = testTask.getDeviceTestResults();
+        List<TestRun> deviceTestResults = testTask.getDeviceTestResults();
         if (deviceTestResults.isEmpty()) {
             return testTask;
         }
@@ -184,7 +184,7 @@ public class TestDataService {
         deviceTestResultRepository.saveAll(deviceTestResults);
 
         List<AndroidTestUnit> list = new ArrayList<>();
-        for (DeviceTestTask deviceTestResult : deviceTestResults) {
+        for (TestRun deviceTestResult : deviceTestResults) {
             attachmentService.saveAttachments(deviceTestResult.getId(), EntityFileRelation.EntityType.TEST_RESULT, deviceTestResult.getAttachments());
 
             List<AndroidTestUnit> testUnitList = deviceTestResult.getTestUnitList();
@@ -211,16 +211,16 @@ public class TestDataService {
         return testTask;
     }
 
-    public DeviceTestTask getDeviceTestTaskWithVideoInfo(String dttId) {
-        DeviceTestTask deviceTestTask = deviceTestResultRepository.getOne(dttId);
+    public TestRun getDeviceTestTaskWithVideoInfo(String dttId) {
+        TestRun testRun = deviceTestResultRepository.getOne(dttId);
         JSONArray deviceTestResInfo = keyValueRepository.getDeviceTestResInfo(dttId);
-        deviceTestTask.setVideoTimeTagArr(deviceTestResInfo);
-        deviceTestTask.setVideoBlobUrl();
-        deviceTestTask.setAttachments(attachmentService.getAttachments(dttId, EntityFileRelation.EntityType.TEST_RESULT));
-        return deviceTestTask;
+        testRun.setVideoTimeTagArr(deviceTestResInfo);
+        testRun.setVideoBlobUrl();
+        testRun.setAttachments(attachmentService.getAttachments(dttId, EntityFileRelation.EntityType.TEST_RESULT));
+        return testRun;
     }
 
-    public DeviceTestTask getDeviceTestTaskByCrashId(String crashId) {
+    public TestRun getDeviceTestTaskByCrashId(String crashId) {
         return deviceTestResultRepository.findByCrashStackId(crashId).orElse(null);
     }
 

--- a/center/src/main/java/com/microsoft/hydralab/center/service/TestDataService.java
+++ b/center/src/main/java/com/microsoft/hydralab/center/service/TestDataService.java
@@ -211,7 +211,7 @@ public class TestDataService {
         return testTask;
     }
 
-    public TestRun getDeviceTestTaskWithVideoInfo(String dttId) {
+    public TestRun getTestRunWithVideoInfo(String dttId) {
         TestRun testRun = deviceTestResultRepository.getOne(dttId);
         JSONArray deviceTestResInfo = keyValueRepository.getDeviceTestResInfo(dttId);
         testRun.setVideoTimeTagArr(deviceTestResInfo);
@@ -220,7 +220,7 @@ public class TestDataService {
         return testRun;
     }
 
-    public TestRun getDeviceTestTaskByCrashId(String crashId) {
+    public TestRun getTestRunByCrashId(String crashId) {
         return deviceTestResultRepository.findByCrashStackId(crashId).orElse(null);
     }
 

--- a/common/src/main/java/com/microsoft/hydralab/common/entity/common/AndroidTestUnit.java
+++ b/common/src/main/java/com/microsoft/hydralab/common/entity/common/AndroidTestUnit.java
@@ -55,7 +55,7 @@ public class AndroidTestUnit implements Serializable {
     private transient File cpuTraceFile;
 
     @Transient
-    private DeviceTestTask deviceTestTask;
+    private TestRun testRun;
 
     @Transient
     public String getTitle() {

--- a/common/src/main/java/com/microsoft/hydralab/common/entity/common/AndroidTestUnit.java
+++ b/common/src/main/java/com/microsoft/hydralab/common/entity/common/AndroidTestUnit.java
@@ -55,7 +55,7 @@ public class AndroidTestUnit implements Serializable {
     private transient File cpuTraceFile;
 
     @Transient
-    private TestRun testRun;
+    private TestRun deviceTestTask;
 
     @Transient
     public String getTitle() {

--- a/common/src/main/java/com/microsoft/hydralab/common/entity/common/TestRun.java
+++ b/common/src/main/java/com/microsoft/hydralab/common/entity/common/TestRun.java
@@ -7,7 +7,6 @@ import com.alibaba.fastjson.JSONObject;
 import com.microsoft.hydralab.common.util.Const;
 import lombok.Data;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.persistence.*;
 import java.io.File;
@@ -18,9 +17,9 @@ import java.util.UUID;
 
 @Data
 @Entity
-@Table(indexes = {
-        @Index(name = "task_id_index", columnList = "test_task_id", unique = false)})
-public class DeviceTestTask implements Serializable {
+@Table(name = "device_test_task", indexes = {
+        @Index(name = "task_id_index", columnList = "test_task_id")})
+public class TestRun implements Serializable {
     //    private static Pattern testResultLine = Pattern.compile("Tests run:\\s+(\\d+),\\s+Failures:\\s+(\\d+)");
     // OK (8 tests)
 //    private static Pattern testResultOkLine = Pattern.compile("OK\\s+\\((\\d+)\\s+tests\\)");
@@ -68,14 +67,14 @@ public class DeviceTestTask implements Serializable {
     @Transient
     private transient List<CommandlineAndTime> commandlineAndTimeList = new ArrayList<>();
     @Transient
-    private transient File deviceTestResultFolder;
+    private transient File testRunResultFolder;
     @Transient
     private transient Logger logger;
 
-    public DeviceTestTask() {
+    public TestRun() {
     }
 
-    public DeviceTestTask(String deviceSerialNumber, String deviceName, String testTaskId) {
+    public TestRun(String deviceSerialNumber, String deviceName, String testTaskId) {
         this.deviceSerialNumber = deviceSerialNumber;
         this.deviceName = deviceName.replace('_', ' ');
         this.testTaskId = testTaskId;

--- a/common/src/main/java/com/microsoft/hydralab/common/entity/common/TestRun.java
+++ b/common/src/main/java/com/microsoft/hydralab/common/entity/common/TestRun.java
@@ -67,7 +67,7 @@ public class TestRun implements Serializable {
     @Transient
     private transient List<CommandlineAndTime> commandlineAndTimeList = new ArrayList<>();
     @Transient
-    private transient File testRunResultFolder;
+    private transient File resultFolder;
     @Transient
     private transient Logger logger;
 

--- a/common/src/main/java/com/microsoft/hydralab/common/entity/common/TestTask.java
+++ b/common/src/main/java/com/microsoft/hydralab/common/entity/common/TestTask.java
@@ -78,7 +78,7 @@ public class TestTask implements Serializable {
     @Transient
     private transient Map<String, String> instrumentationArgs;
     @Transient
-    private List<DeviceTestTask> deviceTestResults = new ArrayList<>();
+    private List<TestRun> deviceTestResults = new ArrayList<>();
     @Transient
     private Map<String, List<DeviceAction>> deviceActions = new HashMap<>();
     private String fileSetId;
@@ -191,7 +191,7 @@ public class TestTask implements Serializable {
         return testTask;
     }
 
-    public synchronized void addTestedDeviceResult(DeviceTestTask deviceTestResult) {
+    public synchronized void addTestedDeviceResult(TestRun deviceTestResult) {
         deviceTestResults.add(deviceTestResult);
     }
 
@@ -260,7 +260,7 @@ public class TestTask implements Serializable {
         if (deviceTestResults.isEmpty()) {
             return;
         }
-        for (DeviceTestTask deviceTestResult : deviceTestResults) {
+        for (TestRun deviceTestResult : deviceTestResults) {
             totalTestCount += deviceTestResult.getTotalCount();
             totalFailCount += deviceTestResult.getFailCount();
         }

--- a/common/src/main/java/com/microsoft/hydralab/common/logger/impl/ADBLogcatCollector.java
+++ b/common/src/main/java/com/microsoft/hydralab/common/logger/impl/ADBLogcatCollector.java
@@ -21,7 +21,7 @@ import java.util.concurrent.TimeUnit;
 
 public class ADBLogcatCollector implements LogCollector {
     private final DeviceInfo connectedDevice;
-    private final TestRun deviceTestResult;
+    private final TestRun testRun;
     private final String pkgName;
     private final Logger infoLogger;
     DeviceManager deviceManager;
@@ -29,11 +29,11 @@ public class ADBLogcatCollector implements LogCollector {
     private boolean started;
     private String loggerFilePath;
 
-    public ADBLogcatCollector(DeviceManager deviceManager, ADBOperateUtil adbOperateUtil, DeviceInfo deviceInfo, String pkgName, TestRun deviceTestResult, Logger logger) {
+    public ADBLogcatCollector(DeviceManager deviceManager, ADBOperateUtil adbOperateUtil, DeviceInfo deviceInfo, String pkgName, TestRun testRun, Logger logger) {
         this.deviceManager = deviceManager;
         this.adbOperateUtil = adbOperateUtil;
         this.connectedDevice = deviceInfo;
-        this.deviceTestResult = deviceTestResult;
+        this.testRun = testRun;
         this.pkgName = pkgName;
         this.infoLogger = logger;
     }
@@ -44,7 +44,7 @@ public class ADBLogcatCollector implements LogCollector {
             return loggerFilePath;
         }
         started = true;
-        loggerFilePath = new File(deviceTestResult.getResultFolder(), "logcat.log").getAbsolutePath();
+        loggerFilePath = new File(testRun.getResultFolder(), "logcat.log").getAbsolutePath();
         runCommand("logcat -G 48M");
         runCommand("logcat -c");
         return loggerFilePath;
@@ -99,8 +99,8 @@ public class ADBLogcatCollector implements LogCollector {
                     logger.info(line);
                 }
                 if (crashLines.length() > 0) {
-                    deviceTestResult.setCrashStack(crashLines.toString());
-                    deviceTestResult.setCrashStackId(UUID.randomUUID().toString());
+                    testRun.setCrashStack(crashLines.toString());
+                    testRun.setCrashStackId(UUID.randomUUID().toString());
                 }
             }
         } catch (IOException e) {
@@ -115,6 +115,6 @@ public class ADBLogcatCollector implements LogCollector {
 
     @Override
     public boolean isCrashFound() {
-        return StringUtils.isNotEmpty(deviceTestResult.getCrashStack());
+        return StringUtils.isNotEmpty(testRun.getCrashStack());
     }
 }

--- a/common/src/main/java/com/microsoft/hydralab/common/logger/impl/ADBLogcatCollector.java
+++ b/common/src/main/java/com/microsoft/hydralab/common/logger/impl/ADBLogcatCollector.java
@@ -3,7 +3,7 @@
 package com.microsoft.hydralab.common.logger.impl;
 
 import com.microsoft.hydralab.common.entity.common.DeviceInfo;
-import com.microsoft.hydralab.common.entity.common.DeviceTestTask;
+import com.microsoft.hydralab.common.entity.common.TestRun;
 import com.microsoft.hydralab.common.logger.LogCollector;
 import com.microsoft.hydralab.common.management.DeviceManager;
 import com.microsoft.hydralab.common.util.ADBOperateUtil;
@@ -21,7 +21,7 @@ import java.util.concurrent.TimeUnit;
 
 public class ADBLogcatCollector implements LogCollector {
     private final DeviceInfo connectedDevice;
-    private final DeviceTestTask deviceTestResult;
+    private final TestRun deviceTestResult;
     private final String pkgName;
     private final Logger infoLogger;
     DeviceManager deviceManager;
@@ -29,7 +29,7 @@ public class ADBLogcatCollector implements LogCollector {
     private boolean started;
     private String loggerFilePath;
 
-    public ADBLogcatCollector(DeviceManager deviceManager, ADBOperateUtil adbOperateUtil, DeviceInfo deviceInfo, String pkgName, DeviceTestTask deviceTestResult, Logger logger) {
+    public ADBLogcatCollector(DeviceManager deviceManager, ADBOperateUtil adbOperateUtil, DeviceInfo deviceInfo, String pkgName, TestRun deviceTestResult, Logger logger) {
         this.deviceManager = deviceManager;
         this.adbOperateUtil = adbOperateUtil;
         this.connectedDevice = deviceInfo;
@@ -44,7 +44,7 @@ public class ADBLogcatCollector implements LogCollector {
             return loggerFilePath;
         }
         started = true;
-        loggerFilePath = new File(deviceTestResult.getDeviceTestResultFolder(), "logcat.log").getAbsolutePath();
+        loggerFilePath = new File(deviceTestResult.getTestRunResultFolder(), "logcat.log").getAbsolutePath();
         runCommand("logcat -G 48M");
         runCommand("logcat -c");
         return loggerFilePath;

--- a/common/src/main/java/com/microsoft/hydralab/common/logger/impl/ADBLogcatCollector.java
+++ b/common/src/main/java/com/microsoft/hydralab/common/logger/impl/ADBLogcatCollector.java
@@ -44,7 +44,7 @@ public class ADBLogcatCollector implements LogCollector {
             return loggerFilePath;
         }
         started = true;
-        loggerFilePath = new File(deviceTestResult.getTestRunResultFolder(), "logcat.log").getAbsolutePath();
+        loggerFilePath = new File(deviceTestResult.getResultFolder(), "logcat.log").getAbsolutePath();
         runCommand("logcat -G 48M");
         runCommand("logcat -c");
         return loggerFilePath;

--- a/common/src/main/java/com/microsoft/hydralab/common/logger/impl/IOSLogCollector.java
+++ b/common/src/main/java/com/microsoft/hydralab/common/logger/impl/IOSLogCollector.java
@@ -19,7 +19,7 @@ import java.util.UUID;
 
 public class IOSLogCollector implements LogCollector {
     private final DeviceInfo connectedDevice;
-    private final TestRun deviceTestResult;
+    private final TestRun testRun;
     private final String pkgName;
     private final Logger infoLogger;
     IOSDeviceManager deviceManager;
@@ -28,10 +28,10 @@ public class IOSLogCollector implements LogCollector {
     private Process logProcess;
     private boolean crashFound;
 
-    public IOSLogCollector(DeviceManager deviceManager, DeviceInfo deviceInfo, String pkgName, TestRun deviceTestResult, Logger logger) {
+    public IOSLogCollector(DeviceManager deviceManager, DeviceInfo deviceInfo, String pkgName, TestRun testRun, Logger logger) {
         this.deviceManager = (IOSDeviceManager) deviceManager;
         this.connectedDevice = deviceInfo;
-        this.deviceTestResult = deviceTestResult;
+        this.testRun = testRun;
         this.pkgName = pkgName;
         this.infoLogger = logger;
     }
@@ -42,10 +42,10 @@ public class IOSLogCollector implements LogCollector {
             return loggerFilePath;
         }
         started = true;
-        loggerFilePath = new File(deviceTestResult.getResultFolder(), "iOSSysLog.log").getAbsolutePath();
+        loggerFilePath = new File(testRun.getResultFolder(), "iOSSysLog.log").getAbsolutePath();
         try {
             // Clear the crash happened before UI test start.
-            IOSUtils.collectCrashInfo(deviceTestResult.getResultFolder() + "/LegacyCrash", connectedDevice, infoLogger);
+            IOSUtils.collectCrashInfo(testRun.getResultFolder() + "/LegacyCrash", connectedDevice, infoLogger);
             logProcess = IOSUtils.startIOSLog(pkgName, loggerFilePath, connectedDevice, infoLogger);
             if (logProcess != null) {
                 connectedDevice.addCurrentProcess(logProcess);
@@ -65,7 +65,7 @@ public class IOSLogCollector implements LogCollector {
         }
         try {
             // Collect the crash logs
-            String crashFilesPath = deviceTestResult.getResultFolder() + "/Crash";
+            String crashFilesPath = testRun.getResultFolder() + "/Crash";
             IOSUtils.collectCrashInfo(crashFilesPath, connectedDevice, infoLogger);
             File dir = new File(crashFilesPath);
             StringBuilder crashLines = new StringBuilder();
@@ -87,8 +87,8 @@ public class IOSLogCollector implements LogCollector {
             }
             if (crashLines.length() > 0) {
                 crashFound = true;
-                deviceTestResult.setCrashStack(crashLines.toString());
-                deviceTestResult.setCrashStackId(UUID.randomUUID().toString());
+                testRun.setCrashStack(crashLines.toString());
+                testRun.setCrashStackId(UUID.randomUUID().toString());
             }
         } catch (IOException e) {
             e.printStackTrace();

--- a/common/src/main/java/com/microsoft/hydralab/common/logger/impl/IOSLogCollector.java
+++ b/common/src/main/java/com/microsoft/hydralab/common/logger/impl/IOSLogCollector.java
@@ -42,10 +42,10 @@ public class IOSLogCollector implements LogCollector {
             return loggerFilePath;
         }
         started = true;
-        loggerFilePath = new File(deviceTestResult.getTestRunResultFolder(), "iOSSysLog.log").getAbsolutePath();
+        loggerFilePath = new File(deviceTestResult.getResultFolder(), "iOSSysLog.log").getAbsolutePath();
         try {
             // Clear the crash happened before UI test start.
-            IOSUtils.collectCrashInfo(deviceTestResult.getTestRunResultFolder() + "/LegacyCrash", connectedDevice, infoLogger);
+            IOSUtils.collectCrashInfo(deviceTestResult.getResultFolder() + "/LegacyCrash", connectedDevice, infoLogger);
             logProcess = IOSUtils.startIOSLog(pkgName, loggerFilePath, connectedDevice, infoLogger);
             if (logProcess != null) {
                 connectedDevice.addCurrentProcess(logProcess);
@@ -65,7 +65,7 @@ public class IOSLogCollector implements LogCollector {
         }
         try {
             // Collect the crash logs
-            String crashFilesPath = deviceTestResult.getTestRunResultFolder() + "/Crash";
+            String crashFilesPath = deviceTestResult.getResultFolder() + "/Crash";
             IOSUtils.collectCrashInfo(crashFilesPath, connectedDevice, infoLogger);
             File dir = new File(crashFilesPath);
             StringBuilder crashLines = new StringBuilder();

--- a/common/src/main/java/com/microsoft/hydralab/common/logger/impl/IOSLogCollector.java
+++ b/common/src/main/java/com/microsoft/hydralab/common/logger/impl/IOSLogCollector.java
@@ -3,7 +3,7 @@
 package com.microsoft.hydralab.common.logger.impl;
 
 import com.microsoft.hydralab.common.entity.common.DeviceInfo;
-import com.microsoft.hydralab.common.entity.common.DeviceTestTask;
+import com.microsoft.hydralab.common.entity.common.TestRun;
 import com.microsoft.hydralab.common.logger.LogCollector;
 import com.microsoft.hydralab.common.management.DeviceManager;
 import com.microsoft.hydralab.common.management.impl.IOSDeviceManager;
@@ -19,7 +19,7 @@ import java.util.UUID;
 
 public class IOSLogCollector implements LogCollector {
     private final DeviceInfo connectedDevice;
-    private final DeviceTestTask deviceTestResult;
+    private final TestRun deviceTestResult;
     private final String pkgName;
     private final Logger infoLogger;
     IOSDeviceManager deviceManager;
@@ -28,7 +28,7 @@ public class IOSLogCollector implements LogCollector {
     private Process logProcess;
     private boolean crashFound;
 
-    public IOSLogCollector(DeviceManager deviceManager, DeviceInfo deviceInfo, String pkgName, DeviceTestTask deviceTestResult, Logger logger) {
+    public IOSLogCollector(DeviceManager deviceManager, DeviceInfo deviceInfo, String pkgName, TestRun deviceTestResult, Logger logger) {
         this.deviceManager = (IOSDeviceManager) deviceManager;
         this.connectedDevice = deviceInfo;
         this.deviceTestResult = deviceTestResult;
@@ -42,10 +42,10 @@ public class IOSLogCollector implements LogCollector {
             return loggerFilePath;
         }
         started = true;
-        loggerFilePath = new File(deviceTestResult.getDeviceTestResultFolder(), "iOSSysLog.log").getAbsolutePath();
+        loggerFilePath = new File(deviceTestResult.getTestRunResultFolder(), "iOSSysLog.log").getAbsolutePath();
         try {
             // Clear the crash happened before UI test start.
-            IOSUtils.collectCrashInfo(deviceTestResult.getDeviceTestResultFolder() + "/LegacyCrash", connectedDevice, infoLogger);
+            IOSUtils.collectCrashInfo(deviceTestResult.getTestRunResultFolder() + "/LegacyCrash", connectedDevice, infoLogger);
             logProcess = IOSUtils.startIOSLog(pkgName, loggerFilePath, connectedDevice, infoLogger);
             if (logProcess != null) {
                 connectedDevice.addCurrentProcess(logProcess);
@@ -65,7 +65,7 @@ public class IOSLogCollector implements LogCollector {
         }
         try {
             // Collect the crash logs
-            String crashFilesPath = deviceTestResult.getDeviceTestResultFolder() + "/Crash";
+            String crashFilesPath = deviceTestResult.getTestRunResultFolder() + "/Crash";
             IOSUtils.collectCrashInfo(crashFilesPath, connectedDevice, infoLogger);
             File dir = new File(crashFilesPath);
             StringBuilder crashLines = new StringBuilder();

--- a/common/src/main/java/com/microsoft/hydralab/common/management/DeviceManager.java
+++ b/common/src/main/java/com/microsoft/hydralab/common/management/DeviceManager.java
@@ -218,7 +218,7 @@ public abstract class DeviceManager {
     public void updateAllDeviceInfo() {
     }
 
-    public abstract LogCollector getLogCollector(@NotNull DeviceInfo deviceInfo, @NotNull String pkgName, @NotNull TestRun deviceTestResult, @NotNull Logger logger);
+    public abstract LogCollector getLogCollector(@NotNull DeviceInfo deviceInfo, @NotNull String pkgName, @NotNull TestRun testRun, @NotNull Logger logger);
 
     public abstract void setProperty(@NotNull DeviceInfo deviceInfo, @NotNull String property, String val, @Nullable Logger logger);
 

--- a/common/src/main/java/com/microsoft/hydralab/common/management/DeviceManager.java
+++ b/common/src/main/java/com/microsoft/hydralab/common/management/DeviceManager.java
@@ -6,7 +6,7 @@ import com.android.ddmlib.InstallException;
 import com.android.ddmlib.TimeoutException;
 import com.microsoft.hydralab.common.entity.center.AgentUser;
 import com.microsoft.hydralab.common.entity.common.DeviceInfo;
-import com.microsoft.hydralab.common.entity.common.DeviceTestTask;
+import com.microsoft.hydralab.common.entity.common.TestRun;
 import com.microsoft.hydralab.common.entity.common.TestTask;
 import com.microsoft.hydralab.common.logger.LogCollector;
 import com.microsoft.hydralab.common.screen.ScreenRecorder;
@@ -218,7 +218,7 @@ public abstract class DeviceManager {
     public void updateAllDeviceInfo() {
     }
 
-    public abstract LogCollector getLogCollector(@NotNull DeviceInfo deviceInfo, @NotNull String pkgName, @NotNull DeviceTestTask deviceTestResult, @NotNull Logger logger);
+    public abstract LogCollector getLogCollector(@NotNull DeviceInfo deviceInfo, @NotNull String pkgName, @NotNull TestRun deviceTestResult, @NotNull Logger logger);
 
     public abstract void setProperty(@NotNull DeviceInfo deviceInfo, @NotNull String property, String val, @Nullable Logger logger);
 

--- a/common/src/main/java/com/microsoft/hydralab/common/management/impl/AndroidDeviceManager.java
+++ b/common/src/main/java/com/microsoft/hydralab/common/management/impl/AndroidDeviceManager.java
@@ -342,8 +342,8 @@ public class AndroidDeviceManager extends DeviceManager {
     }
 
     @Override
-    public ADBLogcatCollector getLogCollector(DeviceInfo deviceInfo, String pkgName, TestRun deviceTestResult, Logger logger) {
-        return new ADBLogcatCollector(this, this.adbOperateUtil, deviceInfo, pkgName, deviceTestResult, logger);
+    public ADBLogcatCollector getLogCollector(DeviceInfo deviceInfo, String pkgName, TestRun testRun, Logger logger) {
+        return new ADBLogcatCollector(this, this.adbOperateUtil, deviceInfo, pkgName, testRun, logger);
     }
 
     @Override

--- a/common/src/main/java/com/microsoft/hydralab/common/management/impl/AndroidDeviceManager.java
+++ b/common/src/main/java/com/microsoft/hydralab/common/management/impl/AndroidDeviceManager.java
@@ -9,7 +9,7 @@ import com.android.ddmlib.IDevice;
 import com.android.ddmlib.InstallException;
 import com.android.ddmlib.RawImage;
 import com.microsoft.hydralab.common.entity.common.DeviceInfo;
-import com.microsoft.hydralab.common.entity.common.DeviceTestTask;
+import com.microsoft.hydralab.common.entity.common.TestRun;
 import com.microsoft.hydralab.common.entity.common.TestTask;
 import com.microsoft.hydralab.common.logger.MultiLineNoCancelLoggingReceiver;
 import com.microsoft.hydralab.common.logger.MultiLineNoCancelReceiver;
@@ -342,7 +342,7 @@ public class AndroidDeviceManager extends DeviceManager {
     }
 
     @Override
-    public ADBLogcatCollector getLogCollector(DeviceInfo deviceInfo, String pkgName, DeviceTestTask deviceTestResult, Logger logger) {
+    public ADBLogcatCollector getLogCollector(DeviceInfo deviceInfo, String pkgName, TestRun deviceTestResult, Logger logger) {
         return new ADBLogcatCollector(this, this.adbOperateUtil, deviceInfo, pkgName, deviceTestResult, logger);
     }
 

--- a/common/src/main/java/com/microsoft/hydralab/common/management/impl/IOSDeviceManager.java
+++ b/common/src/main/java/com/microsoft/hydralab/common/management/impl/IOSDeviceManager.java
@@ -6,7 +6,7 @@ import com.alibaba.fastjson.JSON;
 import com.alibaba.fastjson.JSONArray;
 import com.alibaba.fastjson.JSONObject;
 import com.microsoft.hydralab.common.entity.common.DeviceInfo;
-import com.microsoft.hydralab.common.entity.common.DeviceTestTask;
+import com.microsoft.hydralab.common.entity.common.TestRun;
 import com.microsoft.hydralab.common.logger.LogCollector;
 import com.microsoft.hydralab.common.logger.impl.IOSLogCollector;
 import com.microsoft.hydralab.common.management.DeviceManager;
@@ -185,7 +185,7 @@ public class IOSDeviceManager extends DeviceManager {
     }
 
     @Override
-    public LogCollector getLogCollector(DeviceInfo deviceInfo, String pkgName, DeviceTestTask deviceTestResult, Logger logger) {
+    public LogCollector getLogCollector(DeviceInfo deviceInfo, String pkgName, TestRun deviceTestResult, Logger logger) {
         return new IOSLogCollector(this, deviceInfo, pkgName, deviceTestResult, logger);
     }
 

--- a/common/src/main/java/com/microsoft/hydralab/common/management/impl/IOSDeviceManager.java
+++ b/common/src/main/java/com/microsoft/hydralab/common/management/impl/IOSDeviceManager.java
@@ -185,8 +185,8 @@ public class IOSDeviceManager extends DeviceManager {
     }
 
     @Override
-    public LogCollector getLogCollector(DeviceInfo deviceInfo, String pkgName, TestRun deviceTestResult, Logger logger) {
-        return new IOSLogCollector(this, deviceInfo, pkgName, deviceTestResult, logger);
+    public LogCollector getLogCollector(DeviceInfo deviceInfo, String pkgName, TestRun testRun, Logger logger) {
+        return new IOSLogCollector(this, deviceInfo, pkgName, testRun, logger);
     }
 
     @Override

--- a/common/src/main/java/com/microsoft/hydralab/common/repository/DeviceTestResultRepository.java
+++ b/common/src/main/java/com/microsoft/hydralab/common/repository/DeviceTestResultRepository.java
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 package com.microsoft.hydralab.common.repository;
 
-import com.microsoft.hydralab.common.entity.common.DeviceTestTask;
+import com.microsoft.hydralab.common.entity.common.TestRun;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -10,8 +10,8 @@ import java.util.List;
 import java.util.Optional;
 
 @Repository
-public interface DeviceTestResultRepository extends JpaRepository<DeviceTestTask, String> {
+public interface DeviceTestResultRepository extends JpaRepository<TestRun, String> {
 
-    List<DeviceTestTask> findByTestTaskId(String taskId);
-    Optional<DeviceTestTask> findByCrashStackId(String crashStackId);
+    List<TestRun> findByTestTaskId(String taskId);
+    Optional<TestRun> findByCrashStackId(String crashStackId);
 }

--- a/common/src/main/java/com/microsoft/hydralab/common/repository/KeyValueRepository.java
+++ b/common/src/main/java/com/microsoft/hydralab/common/repository/KeyValueRepository.java
@@ -5,7 +5,7 @@ package com.microsoft.hydralab.common.repository;
 import com.alibaba.fastjson.JSON;
 import com.alibaba.fastjson.JSONArray;
 import com.microsoft.hydralab.common.entity.common.AndroidTestUnit;
-import com.microsoft.hydralab.common.entity.common.DeviceTestTask;
+import com.microsoft.hydralab.common.entity.common.TestRun;
 import com.microsoft.hydralab.common.entity.common.KeyValue;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.cache.annotation.CacheConfig;
@@ -52,7 +52,7 @@ public class KeyValueRepository {
         keyValueRepository.putKeyValuePairDB(CRASH_STACK_IN_DEVICE + crashStackId, crashStack.replace("\n", "<br>"));
     }
 
-    public void saveDeviceTestResultResInfo(DeviceTestTask result) {
+    public void saveDeviceTestResultResInfo(TestRun result) {
         JSONArray videoTimeTagArr = result.getVideoTimeTagArr();
         if (videoTimeTagArr == null) {
             return;

--- a/common/src/main/java/com/microsoft/hydralab/common/repository/TestRunRepository.java
+++ b/common/src/main/java/com/microsoft/hydralab/common/repository/TestRunRepository.java
@@ -10,7 +10,7 @@ import java.util.List;
 import java.util.Optional;
 
 @Repository
-public interface DeviceTestResultRepository extends JpaRepository<TestRun, String> {
+public interface TestRunRepository extends JpaRepository<TestRun, String> {
 
     List<TestRun> findByTestTaskId(String taskId);
     Optional<TestRun> findByCrashStackId(String crashStackId);


### PR DESCRIPTION
rename的主要目的是把概念定义好 一个testRun不再绑定某一台设备 所以把名字里的device去掉，为真正的cross-platform做准备。
Expect no changes on the DB schema and JSON protocols. And all changes happen within the scope of the code.