### PR TITLE
[Perf] WindowsMemoryInspector and WindowsBatteryInspector

### DIFF
--- a/common/src/main/java/com/microsoft/hydralab/common/util/ShellUtils.java
+++ b/common/src/main/java/com/microsoft/hydralab/common/util/ShellUtils.java
@@ -92,7 +92,7 @@ public class ShellUtils {
                 result.append(line);
             }
             return result.toString();
-        } catch (Exception e) {
+        } catch (IOException e) {
             classLogger.error("Fail to run: " + command, e);
         }
 

--- a/common/src/main/java/com/microsoft/hydralab/common/util/ShellUtils.java
+++ b/common/src/main/java/com/microsoft/hydralab/common/util/ShellUtils.java
@@ -11,6 +11,22 @@ public class ShellUtils {
     public static final String POWER_SHELL_PATH = "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe";
     public static boolean isConnectedToWindowsOS = System.getProperty("os.name").startsWith("Windows");
 
+    private static String[] getFullCommand(String command)
+    {
+        String shellProcess = "";
+        String argName = "";
+
+        if (isConnectedToWindowsOS) {
+            shellProcess = POWER_SHELL_PATH;
+            argName = "-Command";
+        } else {
+            shellProcess = "sh";
+            argName = "-c";
+        }
+
+        return new String[]{shellProcess, argName, command};
+    }
+
     @Nullable
     public static Process execLocalCommand(String command, Logger classLogger) {
         return execLocalCommand(command, true, classLogger);
@@ -19,8 +35,10 @@ public class ShellUtils {
     @Nullable
     public static Process execLocalCommand(String command, boolean needWait, Logger classLogger) {
         Process process = null;
+        String[] fullCommand = getFullCommand(command);
+
         try {
-            process = Runtime.getRuntime().exec(command);
+            process = Runtime.getRuntime().exec(fullCommand);
             CommandOutputReceiver err = new CommandOutputReceiver(process.getErrorStream(), classLogger);
             CommandOutputReceiver out = new CommandOutputReceiver(process.getInputStream(), classLogger);
             err.start();
@@ -38,17 +56,9 @@ public class ShellUtils {
 
     @Nullable
     public static Process execLocalCommandWithRedirect(String command, File redirectTo, boolean needWait, Logger classLogger) {
-        String shellProcess = "";
-        String argName = "";
-        if (isConnectedToWindowsOS) {
-            shellProcess = POWER_SHELL_PATH;
-            argName = "-Command";
-        } else {
-            shellProcess = "sh";
-            argName = "-c";
-        }
-        String[] fullCommand = {shellProcess, argName, command + " > " + redirectTo.getAbsolutePath()};
         Process process = null;
+        String[] fullCommand = getFullCommand(command + " | Out-File -FilePath " + redirectTo.getAbsolutePath());
+
         try {
             process = Runtime.getRuntime().exec(fullCommand);
             CommandOutputReceiver err = new CommandOutputReceiver(process.getErrorStream(), classLogger);
@@ -68,8 +78,10 @@ public class ShellUtils {
 
     @Nullable
     public static String execLocalCommandWithResult(String command, Logger classLogger) {
+        String[] fullCommand = getFullCommand(command);
+
         try {
-            Process process = Runtime.getRuntime().exec(command);
+            Process process = Runtime.getRuntime().exec(fullCommand);
             // Getting the results
             process.getOutputStream().close();
             InputStream is = process.getInputStream();
@@ -80,10 +92,11 @@ public class ShellUtils {
                 result.append(line);
             }
             return result.toString();
-        } catch (IOException e) {
+        } catch (Exception e) {
             classLogger.error("Fail to run: " + command, e);
-            return null;
         }
+
+        return null;
     }
 
     public static void killProcessByCommandStr(String commandStr, Logger classLogger) {

--- a/common/src/main/java/com/microsoft/hydralab/common/util/TimeUtils.java
+++ b/common/src/main/java/com/microsoft/hydralab/common/util/TimeUtils.java
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+package com.microsoft.hydralab.common.util;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Locale;
+import java.util.TimeZone;
+
+public class TimeUtils {
+
+    // This function is for filenames, please do not involve the following characters as returned value: \/:*?"<>|
+    public static String getTimestampForFilename() {
+        SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH-mm-ss",
+                Locale.getDefault());
+        TimeZone gmt = TimeZone.getTimeZone("UTC");
+        dateFormat.setTimeZone(gmt);
+        dateFormat.setLenient(true);
+        return dateFormat.format(new Date());
+    }
+
+}

--- a/common/src/main/java/com/microsoft/hydralab/performance/PerformanceTestManagementService.java
+++ b/common/src/main/java/com/microsoft/hydralab/performance/PerformanceTestManagementService.java
@@ -5,8 +5,10 @@ package com.microsoft.hydralab.performance;
 import com.microsoft.hydralab.agent.runner.ITestRun;
 import com.microsoft.hydralab.agent.runner.TestRunThreadContext;
 import com.microsoft.hydralab.performance.inspectors.AndroidBatteryInfoInspector;
+import com.microsoft.hydralab.performance.inspectors.WindowsBatteryInspector;
 import com.microsoft.hydralab.performance.inspectors.WindowsMemoryInspector;
 import com.microsoft.hydralab.performance.parsers.AndroidBatteryInfoResultParser;
+import com.microsoft.hydralab.performance.parsers.WindowsBatteryResultParser;
 import com.microsoft.hydralab.performance.parsers.WindowsMemoryResultParser;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.util.Assert;
@@ -17,19 +19,19 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
-import static com.microsoft.hydralab.performance.PerformanceInspector.PerformanceInspectorType.INSPECTOR_ANDROID_BATTERY_INFO;
-import static com.microsoft.hydralab.performance.PerformanceInspector.PerformanceInspectorType.INSPECTOR_WIN_MEMORY;
-import static com.microsoft.hydralab.performance.PerformanceResultParser.PerformanceResultParserType.PARSER_ANDROID_MEMORY_DUMP;
-import static com.microsoft.hydralab.performance.PerformanceResultParser.PerformanceResultParserType.PARSER_WIN_MEMORY;
+import static com.microsoft.hydralab.performance.PerformanceInspector.PerformanceInspectorType.*;
+import static com.microsoft.hydralab.performance.PerformanceResultParser.PerformanceResultParserType.*;
 
 public class PerformanceTestManagementService implements IPerformanceInspectionService {
     private final Map<PerformanceInspector.PerformanceInspectorType, PerformanceInspector> performanceInspectorMap = Map.of(
             INSPECTOR_ANDROID_BATTERY_INFO, new AndroidBatteryInfoInspector(),
-            INSPECTOR_WIN_MEMORY, new WindowsMemoryInspector()
+            INSPECTOR_WIN_MEMORY, new WindowsMemoryInspector(),
+            INSPECTOR_WIN_BATTERY, new WindowsBatteryInspector()
     );
     private final Map<PerformanceResultParser.PerformanceResultParserType, PerformanceResultParser> performanceResultParserMap = Map.of(
             PARSER_ANDROID_MEMORY_DUMP, new AndroidBatteryInfoResultParser(),
-            PARSER_WIN_MEMORY, new WindowsMemoryResultParser()
+            PARSER_WIN_MEMORY, new WindowsMemoryResultParser(),
+            PARSER_WIN_BATTERY, new WindowsBatteryResultParser()
     );
     private final Map<ITestRun, Map<String, PerformanceTestResult>> testRunPerfResultMap = new ConcurrentHashMap<>();
 

--- a/common/src/main/java/com/microsoft/hydralab/performance/inspectors/AndroidBatteryInfoInspector.java
+++ b/common/src/main/java/com/microsoft/hydralab/performance/inspectors/AndroidBatteryInfoInspector.java
@@ -5,13 +5,10 @@ import com.microsoft.hydralab.performance.PerformanceInspectionResult;
 import com.microsoft.hydralab.performance.PerformanceInspector;
 
 public class AndroidBatteryInfoInspector implements PerformanceInspector {
-    @Override
-    public void initialize(PerformanceInspection performanceInspection) {
-
-    }
 
     @Override
     public PerformanceInspectionResult inspect(PerformanceInspection performanceInspection) {
         return null;
     }
+
 }

--- a/common/src/main/java/com/microsoft/hydralab/performance/inspectors/AndroidBatteryInfoInspector.java
+++ b/common/src/main/java/com/microsoft/hydralab/performance/inspectors/AndroidBatteryInfoInspector.java
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 package com.microsoft.hydralab.performance.inspectors;
 
 import com.microsoft.hydralab.performance.PerformanceInspection;

--- a/common/src/main/java/com/microsoft/hydralab/performance/inspectors/AndroidBatteryInfoInspector.java
+++ b/common/src/main/java/com/microsoft/hydralab/performance/inspectors/AndroidBatteryInfoInspector.java
@@ -6,6 +6,11 @@ import com.microsoft.hydralab.performance.PerformanceInspector;
 
 public class AndroidBatteryInfoInspector implements PerformanceInspector {
     @Override
+    public void initialize(PerformanceInspection performanceInspection) {
+
+    }
+
+    @Override
     public PerformanceInspectionResult inspect(PerformanceInspection performanceInspection) {
         return null;
     }

--- a/common/src/main/java/com/microsoft/hydralab/performance/inspectors/WindowsBatteryInspector.java
+++ b/common/src/main/java/com/microsoft/hydralab/performance/inspectors/WindowsBatteryInspector.java
@@ -21,7 +21,7 @@ import java.util.TimeZone;
  */
 public class WindowsBatteryInspector implements PerformanceInspector {
     private final static String RAW_RESULT_FILE_NAME_FORMAT = "%s_%s.csv";
-    private final static String COMMAND_FORMAT = "powercfg /srumutil /OUTPUT \"%s\" /CSV ";
+    private final static String COMMAND_FORMAT = "Start-Process -FilePath Powershell.exe -Verb RunAs -ArgumentList '-command \"powercfg /srumutil /OUTPUT %s /CSV \"'";
 
     protected Logger classLogger = LoggerFactory.getLogger(getClass());
 

--- a/common/src/main/java/com/microsoft/hydralab/performance/inspectors/WindowsBatteryInspector.java
+++ b/common/src/main/java/com/microsoft/hydralab/performance/inspectors/WindowsBatteryInspector.java
@@ -5,17 +5,14 @@ package com.microsoft.hydralab.performance.inspectors;
 import com.microsoft.hydralab.agent.runner.ITestRun;
 import com.microsoft.hydralab.agent.runner.TestRunThreadContext;
 import com.microsoft.hydralab.common.util.ShellUtils;
+import com.microsoft.hydralab.common.util.TimeUtils;
+import com.microsoft.hydralab.performance.PerformanceInspection;
 import com.microsoft.hydralab.performance.PerformanceInspectionResult;
 import com.microsoft.hydralab.performance.PerformanceInspector;
-import com.microsoft.hydralab.performance.PerformanceInspection;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
-import java.text.SimpleDateFormat;
-import java.util.Date;
-import java.util.Locale;
-import java.util.TimeZone;
 
 /**
  * WindowsBatteryInspector is only suitable for the Windows devices with battery,
@@ -48,7 +45,7 @@ public class WindowsBatteryInspector implements PerformanceInspector {
         }
 
         File rawResultFile = new File(performanceInspection.resultFolder,
-                String.format(RAW_RESULT_FILE_NAME_FORMAT, getClass().getSimpleName(), getTimestamp()));
+                String.format(RAW_RESULT_FILE_NAME_FORMAT, getClass().getSimpleName(), TimeUtils.getTimestampForFilename()));
         Process process = ShellUtils.execLocalCommand(String.format(COMMAND_FORMAT, rawResultFile), false, classLogger);
         PerformanceInspectionResult result = new PerformanceInspectionResult(rawResultFile);
 
@@ -63,15 +60,6 @@ public class WindowsBatteryInspector implements PerformanceInspector {
         }
 
         return result;
-    }
-
-    private String getTimestamp() {
-        SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH_mm_ss",
-                Locale.getDefault());
-        TimeZone gmt = TimeZone.getTimeZone("UTC");
-        dateFormat.setTimeZone(gmt);
-        dateFormat.setLenient(true);
-        return dateFormat.format(new Date());
     }
 
 }

--- a/common/src/main/java/com/microsoft/hydralab/performance/inspectors/WindowsBatteryInspector.java
+++ b/common/src/main/java/com/microsoft/hydralab/performance/inspectors/WindowsBatteryInspector.java
@@ -29,6 +29,7 @@ import java.util.TimeZone;
  * TODO:
  * Need to verify if the agent configured with elevated privileges can bypass the UAC popup without changing the UAC
  * configuration.
+ * Add a new method in ShellUtils to run the admin command if the TODO is not feasible.
  */
 public class WindowsBatteryInspector implements PerformanceInspector {
     private final static String RAW_RESULT_FILE_NAME_FORMAT = "%s_%s.csv";

--- a/common/src/main/java/com/microsoft/hydralab/performance/inspectors/WindowsBatteryInspector.java
+++ b/common/src/main/java/com/microsoft/hydralab/performance/inspectors/WindowsBatteryInspector.java
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 package com.microsoft.hydralab.performance.inspectors;
 
 import com.microsoft.hydralab.agent.runner.ITestRun;

--- a/common/src/main/java/com/microsoft/hydralab/performance/inspectors/WindowsBatteryInspector.java
+++ b/common/src/main/java/com/microsoft/hydralab/performance/inspectors/WindowsBatteryInspector.java
@@ -3,48 +3,30 @@ package com.microsoft.hydralab.performance.inspectors;
 import com.microsoft.hydralab.agent.runner.ITestRun;
 import com.microsoft.hydralab.agent.runner.TestRunThreadContext;
 import com.microsoft.hydralab.common.util.ShellUtils;
-import com.microsoft.hydralab.performance.PerformanceInspection;
 import com.microsoft.hydralab.performance.PerformanceInspectionResult;
 import com.microsoft.hydralab.performance.PerformanceInspector;
-import org.apache.commons.io.FileUtils;
-import org.apache.commons.io.IOUtils;
+import com.microsoft.hydralab.performance.PerformanceInspection;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.*;
+import java.io.File;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Locale;
-import java.util.Objects;
 import java.util.TimeZone;
 
-public class WindowsMemoryInspector implements PerformanceInspector {
-
-    private final static String PROCESS_NAME_KEYWORD = "Phone";
-    private final static String RAW_RESULT_FILE_NAME_FORMAT = "%s_%s_%s";
-    private final static String SCRIPT_NAME = "WindowsMemoryInspector.ps1";
-    private final static File SCRIPT_FILE = new File(SCRIPT_NAME);
-    private final static String PARAMETER_FORMAT = " -keyword %s -output %s";
+/**
+ * WindowsBatteryInspector is only suitable for the Windows devices with battery,
+ * since powercfg command runs only on those devices.
+ */
+public class WindowsBatteryInspector implements PerformanceInspector {
+    private final static String RAW_RESULT_FILE_NAME_FORMAT = "%s_%s.csv";
+    private final static String COMMAND_FORMAT = "powercfg /srumutil /OUTPUT \"%s\" /CSV ";
 
     protected Logger classLogger = LoggerFactory.getLogger(getClass());
 
-    public void initializeIfNeeded(PerformanceInspection performanceInspection) {
-        if (!SCRIPT_FILE.exists()) {
-            try {
-                InputStream resourceAsStream = FileUtils.class.getClassLoader().getResourceAsStream(SCRIPT_NAME);
-                OutputStream out = new FileOutputStream(SCRIPT_FILE);
-                IOUtils.copy(Objects.requireNonNull(resourceAsStream), out);
-                out.close();
-            } catch (IOException e) {
-                classLogger.error("Failed to find app handler script", e);
-            }
-        }
-    }
-
     @Override
     public PerformanceInspectionResult inspect(PerformanceInspection performanceInspection) {
-        initializeIfNeeded(performanceInspection);
-
         ITestRun testRun = TestRunThreadContext.getTestRun();
         if (testRun == null)
         {
@@ -53,10 +35,8 @@ public class WindowsMemoryInspector implements PerformanceInspector {
         }
 
         File rawResultFile = new File(performanceInspection.resultFolder,
-                String.format(RAW_RESULT_FILE_NAME_FORMAT, getClass().getSimpleName(), PROCESS_NAME_KEYWORD, getTimestamp()));
-        Process process = ShellUtils.execLocalCommand(
-                SCRIPT_FILE.getAbsolutePath() + String.format(PARAMETER_FORMAT, PROCESS_NAME_KEYWORD, rawResultFile),
-                false, classLogger);
+                String.format(RAW_RESULT_FILE_NAME_FORMAT, getClass().getSimpleName(), getTimestamp()));
+        Process process = ShellUtils.execLocalCommand(String.format(COMMAND_FORMAT, rawResultFile), false, classLogger);
         PerformanceInspectionResult result = new PerformanceInspectionResult(rawResultFile);
 
         try {

--- a/common/src/main/java/com/microsoft/hydralab/performance/inspectors/WindowsBatteryInspector.java
+++ b/common/src/main/java/com/microsoft/hydralab/performance/inspectors/WindowsBatteryInspector.java
@@ -18,10 +18,20 @@ import java.util.TimeZone;
 /**
  * WindowsBatteryInspector is only suitable for the Windows devices with battery,
  * since powercfg command runs only on those devices.
+ *
+ * Note:
+ * powercfg command needs the elevated privileges of powershell, and UAC (User Account Control) dialog may pop up during
+ * the elevation process to block the testing. There is a workaround to disable the UAC dialog by setting "Never notify"
+ * in the UAC settings panel.
+ *
+ * TODO:
+ * Need to verify if the agent configured with elevated privileges can bypass the UAC popup without changing the UAC
+ * configuration.
  */
 public class WindowsBatteryInspector implements PerformanceInspector {
     private final static String RAW_RESULT_FILE_NAME_FORMAT = "%s_%s.csv";
-    private final static String COMMAND_FORMAT = "Start-Process -FilePath Powershell.exe -Verb RunAs -ArgumentList '-command \"powercfg /srumutil /OUTPUT %s /CSV \"'";
+    private final static String COMMAND_FORMAT = "Start-Process -FilePath Powershell.exe -Verb RunAs -ArgumentList " +
+            "'-command \"powercfg /srumutil /OUTPUT %s /CSV \"'";
 
     protected Logger classLogger = LoggerFactory.getLogger(getClass());
 

--- a/common/src/main/java/com/microsoft/hydralab/performance/inspectors/WindowsMemoryInspector.java
+++ b/common/src/main/java/com/microsoft/hydralab/performance/inspectors/WindowsMemoryInspector.java
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 package com.microsoft.hydralab.performance.inspectors;
 
 import com.microsoft.hydralab.agent.runner.ITestRun;

--- a/common/src/main/java/com/microsoft/hydralab/performance/inspectors/WindowsMemoryInspector.java
+++ b/common/src/main/java/com/microsoft/hydralab/performance/inspectors/WindowsMemoryInspector.java
@@ -19,6 +19,7 @@ import java.util.Objects;
 
 public class WindowsMemoryInspector implements PerformanceInspector {
 
+    // TODO: [Extensible] Make it work with more processes of other Windows apps.
     private final static String PROCESS_NAME_KEYWORD = "Phone";
     private final static String RAW_RESULT_FILE_NAME_FORMAT = "%s_%s_%s";
     private final static String SCRIPT_NAME = "WindowsMemoryInspector.ps1";

--- a/common/src/main/java/com/microsoft/hydralab/performance/inspectors/WindowsMemoryInspector.java
+++ b/common/src/main/java/com/microsoft/hydralab/performance/inspectors/WindowsMemoryInspector.java
@@ -5,6 +5,7 @@ package com.microsoft.hydralab.performance.inspectors;
 import com.microsoft.hydralab.agent.runner.ITestRun;
 import com.microsoft.hydralab.agent.runner.TestRunThreadContext;
 import com.microsoft.hydralab.common.util.ShellUtils;
+import com.microsoft.hydralab.common.util.TimeUtils;
 import com.microsoft.hydralab.performance.PerformanceInspection;
 import com.microsoft.hydralab.performance.PerformanceInspectionResult;
 import com.microsoft.hydralab.performance.PerformanceInspector;
@@ -14,11 +15,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.*;
-import java.text.SimpleDateFormat;
-import java.util.Date;
-import java.util.Locale;
 import java.util.Objects;
-import java.util.TimeZone;
 
 public class WindowsMemoryInspector implements PerformanceInspector {
 
@@ -55,7 +52,7 @@ public class WindowsMemoryInspector implements PerformanceInspector {
         }
 
         File rawResultFile = new File(performanceInspection.resultFolder,
-                String.format(RAW_RESULT_FILE_NAME_FORMAT, getClass().getSimpleName(), PROCESS_NAME_KEYWORD, getTimestamp()));
+                String.format(RAW_RESULT_FILE_NAME_FORMAT, getClass().getSimpleName(), PROCESS_NAME_KEYWORD, TimeUtils.getTimestampForFilename()));
         Process process = ShellUtils.execLocalCommand(
                 SCRIPT_FILE.getAbsolutePath() + String.format(PARAMETER_FORMAT, PROCESS_NAME_KEYWORD, rawResultFile),
                 false, classLogger);
@@ -72,15 +69,6 @@ public class WindowsMemoryInspector implements PerformanceInspector {
         }
 
         return result;
-    }
-
-    private String getTimestamp() {
-        SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH_mm_ss",
-                Locale.getDefault());
-        TimeZone gmt = TimeZone.getTimeZone("UTC");
-        dateFormat.setTimeZone(gmt);
-        dateFormat.setLenient(true);
-        return dateFormat.format(new Date());
     }
 
 }

--- a/common/src/main/java/com/microsoft/hydralab/performance/parsers/AndroidBatteryInfoResultParser.java
+++ b/common/src/main/java/com/microsoft/hydralab/performance/parsers/AndroidBatteryInfoResultParser.java
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 package com.microsoft.hydralab.performance.parsers;
 
 import com.microsoft.hydralab.performance.PerformanceInspectionResult;

--- a/common/src/main/java/com/microsoft/hydralab/performance/parsers/WindowsBatteryResultParser.java
+++ b/common/src/main/java/com/microsoft/hydralab/performance/parsers/WindowsBatteryResultParser.java
@@ -6,7 +6,7 @@ import com.microsoft.hydralab.performance.PerformanceTestResult;
 
 import java.util.List;
 
-public class AndroidBatteryInfoResultParser implements PerformanceResultParser {
+public class WindowsBatteryResultParser implements PerformanceResultParser {
 
     @Override
     public PerformanceTestResult parse(List<PerformanceInspectionResult> performanceInspectionResultList) {

--- a/common/src/main/java/com/microsoft/hydralab/performance/parsers/WindowsBatteryResultParser.java
+++ b/common/src/main/java/com/microsoft/hydralab/performance/parsers/WindowsBatteryResultParser.java
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 package com.microsoft.hydralab.performance.parsers;
 
 import com.microsoft.hydralab.performance.PerformanceInspectionResult;

--- a/common/src/main/java/com/microsoft/hydralab/performance/parsers/WindowsMemoryResultParser.java
+++ b/common/src/main/java/com/microsoft/hydralab/performance/parsers/WindowsMemoryResultParser.java
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 package com.microsoft.hydralab.performance.parsers;
 
 import com.microsoft.hydralab.performance.PerformanceInspectionResult;

--- a/common/src/main/java/com/microsoft/hydralab/performance/parsers/WindowsMemoryResultParser.java
+++ b/common/src/main/java/com/microsoft/hydralab/performance/parsers/WindowsMemoryResultParser.java
@@ -7,8 +7,10 @@ import com.microsoft.hydralab.performance.PerformanceTestResult;
 import java.util.List;
 
 public class WindowsMemoryResultParser implements PerformanceResultParser {
+
     @Override
     public PerformanceTestResult parse(List<PerformanceInspectionResult> performanceInspectionResultList) {
         return null;
     }
+
 }

--- a/common/src/main/resources/WindowsMemoryInspector.ps1
+++ b/common/src/main/resources/WindowsMemoryInspector.ps1
@@ -1,0 +1,12 @@
+param (
+    [string]$keyword = "Phone",
+	[string]$output = ""
+)
+
+if ($output -eq "") {
+    write-host "-output is required."
+    exit 1
+}
+
+Get-Process | Where-Object {$_.ProcessName -like "*$keyword*"} | %{"ID={0} Process_Name={1} CPU_Usage={2} Memory_Usage={3}" -f $_.Id, $_.ProcessName, $_.CPU, $_.PM} | Out-File -FilePath $output
+exit 0

--- a/common/src/main/resources/WindowsMemoryInspector.ps1
+++ b/common/src/main/resources/WindowsMemoryInspector.ps1
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 param (
     [string]$keyword = "Phone",
 	[string]$output = ""

--- a/sdk/src/main/java/com/microsoft/hydralab/agent/runner/TestRunThreadContext.java
+++ b/sdk/src/main/java/com/microsoft/hydralab/agent/runner/TestRunThreadContext.java
@@ -13,7 +13,7 @@ public class TestRunThreadContext {
      * Should be called in the TestRunner setup lifecycle
      * @param testRun
      */
-    public static void init(ITestRun testRun) {
+    static void init(ITestRun testRun) {
         clean();
         testRunThreadLocal.set(testRun);
     }

--- a/sdk/src/main/java/com/microsoft/hydralab/agent/runner/TestRunThreadContext.java
+++ b/sdk/src/main/java/com/microsoft/hydralab/agent/runner/TestRunThreadContext.java
@@ -13,7 +13,7 @@ public class TestRunThreadContext {
      * Should be called in the TestRunner setup lifecycle
      * @param testRun
      */
-    static void init(ITestRun testRun) {
+    public static void init(ITestRun testRun) {
         clean();
         testRunThreadLocal.set(testRun);
     }

--- a/sdk/src/main/java/com/microsoft/hydralab/performance/IPerformanceInspectionService.java
+++ b/sdk/src/main/java/com/microsoft/hydralab/performance/IPerformanceInspectionService.java
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 package com.microsoft.hydralab.performance;
 
 public interface IPerformanceInspectionService {

--- a/sdk/src/main/java/com/microsoft/hydralab/performance/InspectionStrategy.java
+++ b/sdk/src/main/java/com/microsoft/hydralab/performance/InspectionStrategy.java
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 package com.microsoft.hydralab.performance;
 
 public class InspectionStrategy {

--- a/sdk/src/main/java/com/microsoft/hydralab/performance/PerformanceInspection.java
+++ b/sdk/src/main/java/com/microsoft/hydralab/performance/PerformanceInspection.java
@@ -2,8 +2,7 @@ package com.microsoft.hydralab.performance;
 
 import java.io.File;
 
-import static com.microsoft.hydralab.performance.PerformanceInspector.PerformanceInspectorType.INSPECTOR_ANDROID_BATTERY_INFO;
-import static com.microsoft.hydralab.performance.PerformanceInspector.PerformanceInspectorType.INSPECTOR_WIN_BATTERY;
+import static com.microsoft.hydralab.performance.PerformanceInspector.PerformanceInspectorType.*;
 
 public class PerformanceInspection {
 
@@ -32,6 +31,10 @@ public class PerformanceInspection {
         return createWindowsBatteryInspection(appId, deviceIdentifier, description, false);
     }
 
+    public static PerformanceInspection createWindowsMemoryInspection(String appId, String deviceIdentifier, String description) {
+        return createWindowsMemoryInspection(appId, deviceIdentifier, description, false);
+    }
+
     public static PerformanceInspection createAndroidBatteryInfoInspection(String appId, String deviceIdentifier, String description, boolean isReset) {
         return new PerformanceInspection(description, INSPECTOR_ANDROID_BATTERY_INFO, appId, deviceIdentifier, isReset);
     }
@@ -39,4 +42,9 @@ public class PerformanceInspection {
     public static PerformanceInspection createWindowsBatteryInspection(String appId, String deviceIdentifier, String description, boolean isReset) {
         return new PerformanceInspection(description, INSPECTOR_WIN_BATTERY, appId, deviceIdentifier, isReset);
     }
+
+    public static PerformanceInspection createWindowsMemoryInspection(String appId, String deviceIdentifier, String description, boolean isReset) {
+        return new PerformanceInspection(description, INSPECTOR_WIN_MEMORY, appId, deviceIdentifier, isReset);
+    }
+
 }

--- a/sdk/src/main/java/com/microsoft/hydralab/performance/PerformanceInspection.java
+++ b/sdk/src/main/java/com/microsoft/hydralab/performance/PerformanceInspection.java
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 package com.microsoft.hydralab.performance;
 
 import java.io.File;

--- a/sdk/src/main/java/com/microsoft/hydralab/performance/PerformanceInspection.java
+++ b/sdk/src/main/java/com/microsoft/hydralab/performance/PerformanceInspection.java
@@ -6,13 +6,14 @@ import static com.microsoft.hydralab.performance.PerformanceInspector.Performanc
 import static com.microsoft.hydralab.performance.PerformanceInspector.PerformanceInspectorType.INSPECTOR_WIN_BATTERY;
 
 public class PerformanceInspection {
+
     public final PerformanceInspector.PerformanceInspectorType inspectorType;
     public final String appId;
     public final String deviceIdentifier;
     public final String description;
     public final String inspectionKey;
     public final boolean isReset;
-    File resultFolder;
+    public File resultFolder;
 
     public PerformanceInspection(String description, PerformanceInspector.PerformanceInspectorType inspectorType, String appId, String deviceIdentifier, boolean isReset) {
         this.inspectorType = inspectorType;

--- a/sdk/src/main/java/com/microsoft/hydralab/performance/PerformanceInspectionResult.java
+++ b/sdk/src/main/java/com/microsoft/hydralab/performance/PerformanceInspectionResult.java
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 package com.microsoft.hydralab.performance;
 
 import java.io.File;

--- a/sdk/src/main/java/com/microsoft/hydralab/performance/PerformanceInspectionResult.java
+++ b/sdk/src/main/java/com/microsoft/hydralab/performance/PerformanceInspectionResult.java
@@ -3,15 +3,17 @@ package com.microsoft.hydralab.performance;
 import java.io.File;
 
 public class PerformanceInspectionResult {
+
     public final long timestamp;
     public PerformanceInspection inspection;
 
-    public File profilingRawResultFile;
+    public File rawResultFile;
     // TODO: restrict the size of it.
     public Object parsedData;
 
-    public PerformanceInspectionResult() {
+    public PerformanceInspectionResult(File rawResultFile) {
         this.timestamp = System.currentTimeMillis();
+        this.rawResultFile = rawResultFile;
     }
 
     //TODO: overwrite equals, toString, and hashcode methods

--- a/sdk/src/main/java/com/microsoft/hydralab/performance/PerformanceInspectionService.java
+++ b/sdk/src/main/java/com/microsoft/hydralab/performance/PerformanceInspectionService.java
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 package com.microsoft.hydralab.performance;
 
 public enum PerformanceInspectionService implements IPerformanceInspectionService {

--- a/sdk/src/main/java/com/microsoft/hydralab/performance/PerformanceInspector.java
+++ b/sdk/src/main/java/com/microsoft/hydralab/performance/PerformanceInspector.java
@@ -1,6 +1,7 @@
 package com.microsoft.hydralab.performance;
 
 public interface PerformanceInspector {
+
     enum PerformanceInspectorType {
         INSPECTOR_ANDROID_MEMORY_DUMP,
         INSPECTOR_ANDROID_MEMORY_INFO,
@@ -10,4 +11,5 @@ public interface PerformanceInspector {
     }
 
     PerformanceInspectionResult inspect(PerformanceInspection performanceInspection);
+
 }

--- a/sdk/src/main/java/com/microsoft/hydralab/performance/PerformanceInspector.java
+++ b/sdk/src/main/java/com/microsoft/hydralab/performance/PerformanceInspector.java
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 package com.microsoft.hydralab.performance;
 
 public interface PerformanceInspector {

--- a/sdk/src/main/java/com/microsoft/hydralab/performance/PerformanceResultParser.java
+++ b/sdk/src/main/java/com/microsoft/hydralab/performance/PerformanceResultParser.java
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 package com.microsoft.hydralab.performance;
 
 import java.util.List;

--- a/sdk/src/main/java/com/microsoft/hydralab/performance/PerformanceTestResult.java
+++ b/sdk/src/main/java/com/microsoft/hydralab/performance/PerformanceTestResult.java
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 package com.microsoft.hydralab.performance;
 
 import java.util.ArrayList;


### PR DESCRIPTION
**Changes**
1. Implement WindowsMemoryInspector and WindowsBatteryInspector.
2. Optimize ShellUtils and make all its functions support both powershell and sh.
3. Add WindowsMemoryInspector.ps1 to avoid null output from piped commands when using Runtime.getRuntime().exec().

**TODO**
1. Implement WindowsMemoryResultParser and WindowsBatteryResultParser.
2. Refine WindowsMemoryInspector.ps1 if needed.