### PR TITLE
Add star button in the homepage list

### DIFF
--- a/react/src/component/Dashboard.jsx
+++ b/react/src/component/Dashboard.jsx
@@ -10,6 +10,7 @@ import AppBar from '@material-ui/core/AppBar';
 import Toolbar from '@material-ui/core/Toolbar';
 import List from '@material-ui/core/List';
 import Divider from '@material-ui/core/Divider';
+import Tooltip from "@mui/material/Tooltip";
 import Grid from '@material-ui/core/Grid';
 import Paper from '@material-ui/core/Paper';
 import DeviceAgentsView from '@/component/DeviceAgentsView'
@@ -246,16 +247,19 @@ export default function Dashboard() {
                                 </ListItemIcon>
                                 <ListItemText primary="Team Management" />
                             </ListItem>
-                            <ListItem component="a" href='https://microsoft.github.io/HydraLab/' target="_blank"
+                            <ListItem component="a" href='https://github.com/microsoft/HydraLab/blob/main/README.md' target="_blank"
                                       rel="noopener noreferrer" button>
                                 <ListItemIcon>
                                     <span className="material-icons-outlined">info</span>
                                 </ListItemIcon>
                                 <ListItemText primary="About"/>
                             </ListItem>
+                            <Tooltip title={"Star microsoft/HydraLab on GitHub"}>
+                                <iframe style={{float:'right',margin:'10px'}} src="https://ghbtns.com/github-btn.html?user=microsoft&repo=HydraLab&type=star&count=true" frameborder="0" scrolling="0" width="90" height="25" title="GitHub"></iframe>
+                            </Tooltip>
                             <ListItem
                                 style={{
-                                    height: "calc(100vh - 561px)",
+                                    height: "calc(100vh - 610px)",
                                     pointerEvents: "none"
                                 }}>
                             </ListItem>

--- a/react/src/component/Dashboard.jsx
+++ b/react/src/component/Dashboard.jsx
@@ -253,6 +253,9 @@ export default function Dashboard() {
                                     <span className="material-icons-outlined">info</span>
                                 </ListItemIcon>
                                 <ListItemText primary="About"/>
+                                <iframe style={{margin: '6px 0px 0px 0px'}}
+                                        src="https://ghbtns.com/github-btn.html?user=microsoft&repo=HydraLab&type=star&count=true"
+                                        frameBorder="0" scrolling="0" align="right" width="90" height="25" title="GitHub"></iframe>
                             </ListItem>
                             <Tooltip title={"Star microsoft/HydraLab on GitHub"}>
                                 {/* More details in https://ghbtns.com/ */}

--- a/react/src/component/Dashboard.jsx
+++ b/react/src/component/Dashboard.jsx
@@ -257,13 +257,9 @@ export default function Dashboard() {
                                         src="https://ghbtns.com/github-btn.html?user=microsoft&repo=HydraLab&type=star&count=true"
                                         frameBorder="0" scrolling="0" align="right" width="90" height="25" title="GitHub"></iframe>
                             </ListItem>
-                            <Tooltip title={"Star microsoft/HydraLab on GitHub"}>
-                                {/* More details in https://ghbtns.com/ */}
-                                <iframe style={{float:'right',margin:'5px 12px 0px 0px'}} src="https://ghbtns.com/github-btn.html?user=microsoft&repo=HydraLab&type=star&count=true" frameborder="0" scrolling="0" width="90" height="25" title="GitHub"></iframe>
-                            </Tooltip>
                             <ListItem
                                 style={{
-                                    height: "calc(100vh - 590px)",
+                                    height: "calc(100vh - 561px)",
                                     pointerEvents: "none"
                                 }}>
                             </ListItem>

--- a/react/src/component/Dashboard.jsx
+++ b/react/src/component/Dashboard.jsx
@@ -260,7 +260,7 @@ export default function Dashboard() {
                             </Tooltip>
                             <ListItem
                                 style={{
-                                    height: "calc(100vh - 610px)",
+                                    height: "calc(100vh - 590px)",
                                     pointerEvents: "none"
                                 }}>
                             </ListItem>

--- a/react/src/component/Dashboard.jsx
+++ b/react/src/component/Dashboard.jsx
@@ -255,7 +255,8 @@ export default function Dashboard() {
                                 <ListItemText primary="About"/>
                             </ListItem>
                             <Tooltip title={"Star microsoft/HydraLab on GitHub"}>
-                                <iframe style={{float:'right',margin:'10px'}} src="https://ghbtns.com/github-btn.html?user=microsoft&repo=HydraLab&type=star&count=true" frameborder="0" scrolling="0" width="90" height="25" title="GitHub"></iframe>
+                                {/* More details in https://ghbtns.com/ */}
+                                <iframe style={{float:'right',margin:'5px 12px 0px 0px'}} src="https://ghbtns.com/github-btn.html?user=microsoft&repo=HydraLab&type=star&count=true" frameborder="0" scrolling="0" width="90" height="25" title="GitHub"></iframe>
                             </Tooltip>
                             <ListItem
                                 style={{

--- a/react/src/component/HeaderView.jsx
+++ b/react/src/component/HeaderView.jsx
@@ -56,7 +56,7 @@ export default class HeaderView extends BaseView {
         const helpSettings = [
             { text: 'Feedback', href: 'https://forms.office.com/r/0wnc2Sk0tp' },
             { text: 'Wiki', href: 'https://github.com/microsoft/HydraLab/wiki' },
-            { text: 'About', href: 'https://microsoft.github.io/HydraLab/' }
+            { text: 'About', href: 'https://github.com/microsoft/HydraLab/blob/main/README.md' }
         ];
         const {teamList, changeDefaultTeamIsShown} = this.state
 

--- a/react/webpack.config.js
+++ b/react/webpack.config.js
@@ -11,9 +11,9 @@ const htmlPlugin = new HtmlWebPackPlugin({
 })
 const distPath = '../center/src/main/resources/static/dist'
 // Change the following endpoint address to point it to your Hydra Lab API service
-const devHydraLabServiceEndpoint = 'http://localhost:9886'
-const testHostPath = {
-    target: devHydraLabServiceEndpoint,
+const devHydraLabServerEndpoint = 'http://localhost:9886'
+const devHydraLabServer = {
+    target: devHydraLabServerEndpoint,
     secure: false,
     changeOrigin: true,
     // if you Hydra Lab Center Service enabled the OAuth, this node needed to be configured/uncommented.
@@ -35,11 +35,11 @@ module.exports = env => {
         devServer: {
             port: 9999,
             proxy: {
-                '/api': testHostPath,
-                '/devices': testHostPath,
-                '/test': testHostPath,
+                '/api': devHydraLabServer,
+                '/devices': devHydraLabServer,
+                '/test': devHydraLabServer,
                 '/images': {
-                    target: testHostPath,
+                    target: devHydraLabServer,
                     pathRewrite: { '^/images': '/src/images' }
                 }
             }

--- a/react/webpack.config.js
+++ b/react/webpack.config.js
@@ -2,7 +2,7 @@ const path = require('path')
 const HtmlWebPackPlugin = require('html-webpack-plugin')
 const CopyPlugin = require("copy-webpack-plugin")
 const TerserPlugin = require("terser-webpack-plugin")
-const webpack = require('webpack');
+const webpack = require('webpack')
 const CompressionPlugin = require("compression-webpack-plugin")
 
 const htmlPlugin = new HtmlWebPackPlugin({
@@ -10,16 +10,18 @@ const htmlPlugin = new HtmlWebPackPlugin({
     filename: 'index.html'
 })
 const distPath = '../center/src/main/resources/static/dist'
+// Change the following endpoint address to point it to your Hydra Lab API service
+const devHydraLabServiceEndpoint = 'http://localhost:9886'
 const testHostPath = {
-    target: 'YOUR_HOST_ADDR',
+    target: devHydraLabServiceEndpoint,
     secure: false,
-    changeOrigin: true
+    changeOrigin: true,
+    // if you Hydra Lab Center Service enabled the OAuth, this node needed to be configured/uncommented.
+    // The Authorization token is accessible in page Authentication -> TOKENS, click the add token button to create if there isn't one.
+    // headers: {
+    //     'Authorization': '*******',
+    // }
 }
-// const testHostPath = 'http://localhost:9886'
-// in dev mode the testHostPath need to add token
-//      headers: {
-//         'Authorization':'*******',
-//     }
 // About Terser https://webpack.js.org/plugins/terser-webpack-plugin/
 // about ENV usage: https://webpack.js.org/guides/environment-variables/
 module.exports = env => {


### PR DESCRIPTION
- Clean up webpack config for dev env
- Replace the https://microsoft.github.io/HydraLab/ entry, since we won't maintain it in a short time.

Here is how the star button looks like:
![image](https://user-images.githubusercontent.com/8344245/216735856-39f64a8b-9707-4528-b538-7cf487e80369.png)
