### PR TITLE
Fix lint warning in AndroidBatteryInfoResultParser

### DIFF
--- a/common/src/main/java/com/microsoft/hydralab/performance/parsers/AndroidBatteryInfoResultParser.java
+++ b/common/src/main/java/com/microsoft/hydralab/performance/parsers/AndroidBatteryInfoResultParser.java
@@ -64,7 +64,6 @@ public class AndroidBatteryInfoResultParser implements PerformanceResultParser {
                 inputLine = inputLine.trim().toLowerCase();
                 contents.add(inputLine);
             }
-            in.close();
 
             //Find Uid
             for (String line : contents) {


### PR DESCRIPTION
warning: [try] explicit call to close() on an auto-closeable resource: in.close();