### PR TITLE
Add page source info in error when T2C fails test

### DIFF
--- a/taps_to_cases/runner/src/main/java/com/microsoft/hydralab/t2c/runner/T2CAppiumUtils.java
+++ b/taps_to_cases/runner/src/main/java/com/microsoft/hydralab/t2c/runner/T2CAppiumUtils.java
@@ -59,7 +59,8 @@ public class T2CAppiumUtils {
             int index = actionInfo.getId();
             logger.error("doAction at step " + index + "with exception: " + e.getMessage());
             if (!isOption) {
-                throw new IllegalStateException("Failed at step " + index + ": " + e.getMessage(), e);
+                throw new IllegalStateException("Failed at step " + index + ": " + e.getMessage()
+                        + ", page source: \n" + driver.webDriver.getPageSource(), e);
             }
         }
     }


### PR DESCRIPTION
Add page source content from webdriver when T2C fails the test case.