### PR TITLE
Refactor T2C runner about "findElment"

### DIFF
--- a/taps_to_cases/runner/src/main/java/com/microsoft/hydralab/t2c/runner/T2CAppiumUtils.java
+++ b/taps_to_cases/runner/src/main/java/com/microsoft/hydralab/t2c/runner/T2CAppiumUtils.java
@@ -28,23 +28,9 @@ public class T2CAppiumUtils {
         WebElement elementFinded = null;
         if (element == null) return null;
         Map<String, String> keyToVal = element.getBasisSearchedBy();
-        if (keyToVal.get("accessibilityId") != null && keyToVal.get("accessibilityId").length() != 0) {
-            elementFinded = driver.findElementByAccessibilityId(keyToVal.get("accessibilityId"));
-            if (elementFinded != null) {
-                return elementFinded;
-            }
-        }
-        if (keyToVal.get("text") != null && keyToVal.get("text").length() != 0) {
-            elementFinded = driver.findElementByName(keyToVal.get("text"));
-            if (elementFinded != null) {
-                return elementFinded;
-            }
-        }
-        if (keyToVal.get("xpath") != null && keyToVal.get("xpath").length() != 0) {
-            elementFinded = driver.findElementByXPath(keyToVal.get("xpath"));
-            if (elementFinded != null) {
-                return elementFinded;
-            }
+        elementFinded = driver.findElementBy(keyToVal);
+        if (elementFinded != null) {
+            return elementFinded;
         }
         logger.warn("Page source: " + driver.webDriver.getPageSource());
         throw new IllegalArgumentException("Element can not be found in current UI. Element info is " + element.getElementInfo());
@@ -186,7 +172,7 @@ public class T2CAppiumUtils {
                 } else if (toElementStr != null) {
                     BaseElementInfo toElementInfo;
                     if (driver instanceof AndroidDriverController) {
-                        toElementInfo = AndroidElementInfo.getAndroidElementFromJson(JSONObject.parseObject(toElementStr));
+                        toElementInfo = JSON.parseObject(toElementStr, AndroidElementInfo.class);
                     } else if (driver instanceof WindowsDriverController) {
                         toElementInfo = JSON.parseObject(toElementStr, WindowsElementInfo.class);
                     } else if (driver instanceof EdgeDriverController) {

--- a/taps_to_cases/runner/src/main/java/com/microsoft/hydralab/t2c/runner/T2CAppiumUtils.java
+++ b/taps_to_cases/runner/src/main/java/com/microsoft/hydralab/t2c/runner/T2CAppiumUtils.java
@@ -3,7 +3,6 @@
 package com.microsoft.hydralab.t2c.runner;
 
 import com.alibaba.fastjson.JSON;
-import com.alibaba.fastjson.JSONObject;
 import com.microsoft.hydralab.t2c.runner.controller.AndroidDriverController;
 import com.microsoft.hydralab.t2c.runner.controller.BaseDriverController;
 import com.microsoft.hydralab.t2c.runner.controller.EdgeDriverController;
@@ -12,6 +11,8 @@ import com.microsoft.hydralab.t2c.runner.elements.AndroidElementInfo;
 import com.microsoft.hydralab.t2c.runner.elements.BaseElementInfo;
 import com.microsoft.hydralab.t2c.runner.elements.EdgeElementInfo;
 import com.microsoft.hydralab.t2c.runner.elements.WindowsElementInfo;
+import com.microsoft.hydralab.t2c.runner.finder.ElementFinder;
+import com.microsoft.hydralab.t2c.runner.finder.ElementFinderFactory;
 import io.appium.java_client.android.nativekey.AndroidKey;
 import org.jetbrains.annotations.NotNull;
 import org.openqa.selenium.WebElement;
@@ -25,14 +26,14 @@ public class T2CAppiumUtils {
     private static boolean isSelfTesting = false;
 
     public static WebElement findElement(BaseDriverController driver, BaseElementInfo element, Logger logger) {
-        WebElement elementFinded = null;
+        WebElement elementFound = null;
         if (element == null) return null;
-        Map<String, String> keyToVal = element.getBasisSearchedBy();
-        elementFinded = driver.findElementBy(keyToVal);
-        if (elementFinded != null) {
-            return elementFinded;
+        ElementFinder<BaseElementInfo> finder = ElementFinderFactory.createElementFinder(driver);
+        elementFound = finder.findElement(element);
+        if (elementFound != null) {
+            return elementFound;
         }
-        logger.warn("Page source: " + driver.webDriver.getPageSource());
+        logger.warn("Page source: " + driver.getPageSource());
         throw new IllegalArgumentException("Element can not be found in current UI. Element info is " + element.getElementInfo());
     }
 
@@ -47,7 +48,7 @@ public class T2CAppiumUtils {
             logger.error("doAction at " + index + ", description: " + description + ", with exception: " + e.getMessage());
             if (!isOption) {
                 throw new IllegalStateException("Failed at " + index + ", description: " + description + ", " + e.getMessage()
-                        + ", page source: \n" + driver.webDriver.getPageSource(), e);
+                        + ", page source: \n" + driver.getPageSource(), e);
             }
         }
     }

--- a/taps_to_cases/runner/src/main/java/com/microsoft/hydralab/t2c/runner/T2CJsonParser.java
+++ b/taps_to_cases/runner/src/main/java/com/microsoft/hydralab/t2c/runner/T2CJsonParser.java
@@ -85,7 +85,7 @@ public class T2CJsonParser {
 
             if (elementInfo != null && !elementInfo.isEmpty()) {
                 if (driveIdToTypeMap.get(driverId).equals("android")) {
-                    androidElement = AndroidElementInfo.getAndroidElementFromJson(elementInfo);
+                    androidElement = JSON.parseObject(caseJsonObject.getString("elementInfo"), AndroidElementInfo.class);
                     actionInfo = new ActionInfo(i, androidElement, actionType, arguments, driverId, description, isOptional);
                 }
                 if (driveIdToTypeMap.get(driverId).equals("windows")) {

--- a/taps_to_cases/runner/src/main/java/com/microsoft/hydralab/t2c/runner/controller/AndroidDriverController.java
+++ b/taps_to_cases/runner/src/main/java/com/microsoft/hydralab/t2c/runner/controller/AndroidDriverController.java
@@ -134,54 +134,13 @@ public class AndroidDriverController extends BaseDriverController {
     }
 
     @Override
-    public WebElement findElementByName(String name) {
-        WebElement elementFound = null;
-        try {
-            elementFound = new WebDriverWait(webDriver, Duration.ofSeconds(10))
-                    .until(driver -> driver.findElement(AppiumBy.xpath("//*[@text='" + name + "']")));
-        } catch (Exception e) {
-            logger.info("Can not find element by text: " + name);
-        }
-        return elementFound;
-    }
-
-    @Override
-    public WebElement findElementBy(Map<String, String> propertyMap) {
-        WebElement elementFound;
-        if (propertyMap.get("accessibilityId") != null && propertyMap.get("accessibilityId").length() != 0) {
-            elementFound = findElementByAccessibilityId(propertyMap.get("accessibilityId"));
-            return elementFound;
-        }
-        if (propertyMap.get("resource-id") != null && propertyMap.get("resource-id").length() != 0) {
-            elementFound = findElementById(propertyMap.get("resource-id"));
-            return elementFound;
-        }
-        if (propertyMap.get("text") != null && propertyMap.get("text").length() != 0) {
-            elementFound = findElementByName(propertyMap.get("text"));
-            return elementFound;
-        }
-        if (propertyMap.get("xpath") != null && propertyMap.get("xpath").length() != 0) {
-            elementFound = findElementByXPath(propertyMap.get("xpath"));
-            return elementFound;
-        }
-        return null;
-    }
-
-
-    private WebElement findElementById(String id) {
-        WebElement elementFound = null;
-        try {
-            elementFound = new WebDriverWait(webDriver, Duration.ofSeconds(10))
-                    .until(driver -> driver.findElement(AppiumBy.name(id)));
-        } catch (Exception e) {
-            logger.info("Can not find element by id: " + id);
-        }
-        return elementFound;
-    }
-
-    @Override
     public void setClipboard(String text) {
         androidDriver.setClipboardText(text);
+    }
+
+    @Override
+    public String getPageSource() {
+        return androidDriver.getPageSource();
     }
 
     @Override

--- a/taps_to_cases/runner/src/main/java/com/microsoft/hydralab/t2c/runner/controller/AndroidDriverController.java
+++ b/taps_to_cases/runner/src/main/java/com/microsoft/hydralab/t2c/runner/controller/AndroidDriverController.java
@@ -146,6 +146,40 @@ public class AndroidDriverController extends BaseDriverController {
     }
 
     @Override
+    public WebElement findElementBy(Map<String, String> propertyMap) {
+        WebElement elementFound;
+        if (propertyMap.get("accessibilityId") != null && propertyMap.get("accessibilityId").length() != 0) {
+            elementFound = findElementByAccessibilityId(propertyMap.get("accessibilityId"));
+            return elementFound;
+        }
+        if (propertyMap.get("resource-id") != null && propertyMap.get("resource-id").length() != 0) {
+            elementFound = findElementById(propertyMap.get("resource-id"));
+            return elementFound;
+        }
+        if (propertyMap.get("text") != null && propertyMap.get("text").length() != 0) {
+            elementFound = findElementByName(propertyMap.get("text"));
+            return elementFound;
+        }
+        if (propertyMap.get("xpath") != null && propertyMap.get("xpath").length() != 0) {
+            elementFound = findElementByXPath(propertyMap.get("xpath"));
+            return elementFound;
+        }
+        return null;
+    }
+
+
+    private WebElement findElementById(String id) {
+        WebElement elementFound = null;
+        try {
+            elementFound = new WebDriverWait(webDriver, Duration.ofSeconds(10))
+                    .until(driver -> driver.findElement(AppiumBy.name(id)));
+        } catch (Exception e) {
+            logger.info("Can not find element by id: " + id);
+        }
+        return elementFound;
+    }
+
+    @Override
     public void setClipboard(String text) {
         androidDriver.setClipboardText(text);
     }

--- a/taps_to_cases/runner/src/main/java/com/microsoft/hydralab/t2c/runner/controller/BaseDriverController.java
+++ b/taps_to_cases/runner/src/main/java/com/microsoft/hydralab/t2c/runner/controller/BaseDriverController.java
@@ -15,10 +15,9 @@ import org.openqa.selenium.support.ui.WebDriverWait;
 import org.slf4j.Logger;
 
 import java.time.Duration;
-import java.util.Map;
 
 public abstract class BaseDriverController {
-    public WebDriver webDriver;
+    protected WebDriver webDriver;
     protected Logger logger;
 
     public BaseDriverController(WebDriver webDriver, Logger logger) {
@@ -142,6 +141,7 @@ public abstract class BaseDriverController {
     public void setClipboard(String text) {
     }
 
+    @Nullable
     public WebElement findElementByAccessibilityId(String accessibilityId) {
         WebElement elementFound = null;
         try {
@@ -159,6 +159,7 @@ public abstract class BaseDriverController {
         return elementFound;
     }
 
+    @Nullable
     public WebElement findElementByXPath(String xpath) {
         WebElement elementFound = null;
         try {
@@ -170,16 +171,32 @@ public abstract class BaseDriverController {
         return elementFound;
     }
 
-    public WebElement findElementByName(String name) {
+    @Nullable
+    public WebElement findElementByText(String text) {
         WebElement elementFound = null;
         try {
             elementFound = new WebDriverWait(webDriver, Duration.ofSeconds(10))
-                    .until(driver -> driver.findElement(AppiumBy.name(name)));
+                    .until(driver -> driver.findElement(AppiumBy.xpath("//*[@text='" + text + "']")));
         } catch (Exception e) {
-            logger.info("Can not find element by name: " + name);
+            logger.info("Can not find element by text: " + text);
         }
         return elementFound;
     }
 
-    public abstract @Nullable WebElement findElementBy(Map<String, String> propertyMap);
+
+    @Nullable
+    public WebElement findElementById(String id) {
+        WebElement elementFound = null;
+        try {
+            elementFound = new WebDriverWait(webDriver, Duration.ofSeconds(10))
+                    .until(driver -> driver.findElement(AppiumBy.name(id)));
+        } catch (Exception e) {
+            logger.info("Can not find element by id: " + id);
+        }
+        return elementFound;
+    }
+
+
+    public abstract String getPageSource();
+
 }

--- a/taps_to_cases/runner/src/main/java/com/microsoft/hydralab/t2c/runner/controller/BaseDriverController.java
+++ b/taps_to_cases/runner/src/main/java/com/microsoft/hydralab/t2c/runner/controller/BaseDriverController.java
@@ -4,6 +4,7 @@ package com.microsoft.hydralab.t2c.runner.controller;
 
 import io.appium.java_client.AppiumBy;
 import io.appium.java_client.android.nativekey.AndroidKey;
+import org.jetbrains.annotations.Nullable;
 import org.openqa.selenium.Dimension;
 import org.openqa.selenium.Point;
 import org.openqa.selenium.WebDriver;
@@ -14,8 +15,9 @@ import org.openqa.selenium.support.ui.WebDriverWait;
 import org.slf4j.Logger;
 
 import java.time.Duration;
+import java.util.Map;
 
-public class BaseDriverController {
+public abstract class BaseDriverController {
     public WebDriver webDriver;
     protected Logger logger;
 
@@ -178,4 +180,6 @@ public class BaseDriverController {
         }
         return elementFound;
     }
+
+    public abstract @Nullable WebElement findElementBy(Map<String, String> propertyMap);
 }

--- a/taps_to_cases/runner/src/main/java/com/microsoft/hydralab/t2c/runner/controller/BaseDriverController.java
+++ b/taps_to_cases/runner/src/main/java/com/microsoft/hydralab/t2c/runner/controller/BaseDriverController.java
@@ -2,6 +2,8 @@
 // Licensed under the MIT License.
 package com.microsoft.hydralab.t2c.runner.controller;
 
+import com.microsoft.hydralab.t2c.runner.elements.AndroidElementInfo;
+import com.microsoft.hydralab.t2c.runner.elements.WindowsElementInfo;
 import io.appium.java_client.AppiumBy;
 import io.appium.java_client.android.nativekey.AndroidKey;
 import org.jetbrains.annotations.Nullable;
@@ -184,6 +186,12 @@ public abstract class BaseDriverController {
     }
 
 
+    /**
+     * In windows, id refers to {@link WindowsElementInfo#getName()}
+     * In android, id refers to {@link AndroidElementInfo#getResourceId()}
+     * @param id
+     * @return
+     */
     @Nullable
     public WebElement findElementById(String id) {
         WebElement elementFound = null;

--- a/taps_to_cases/runner/src/main/java/com/microsoft/hydralab/t2c/runner/controller/EdgeDriverController.java
+++ b/taps_to_cases/runner/src/main/java/com/microsoft/hydralab/t2c/runner/controller/EdgeDriverController.java
@@ -1,6 +1,7 @@
 package com.microsoft.hydralab.t2c.runner.controller;
 
 import io.appium.java_client.windows.WindowsDriver;
+import org.jetbrains.annotations.Nullable;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.edge.EdgeDriver;
 import org.openqa.selenium.interactions.PointerInput;
@@ -15,6 +16,7 @@ import java.awt.datatransfer.UnsupportedFlavorException;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.Arrays;
+import java.util.Map;
 
 public class EdgeDriverController extends BaseDriverController {
     EdgeDriver edgeDriver;
@@ -47,6 +49,24 @@ public class EdgeDriverController extends BaseDriverController {
         StringSelection selection = new StringSelection(text);
         Clipboard clipboard = Toolkit.getDefaultToolkit().getSystemClipboard();
         clipboard.setContents(selection, null);
+    }
+
+    @Override
+    public @Nullable WebElement findElementBy(Map<String, String> propertyMap) {
+        WebElement elementFound = null;
+        if (propertyMap.get("accessibilityId") != null && propertyMap.get("accessibilityId").length() != 0) {
+            elementFound = findElementByAccessibilityId(propertyMap.get("accessibilityId"));
+            return elementFound;
+        }
+        if (propertyMap.get("text") != null && propertyMap.get("text").length() != 0) {
+            elementFound = findElementByName(propertyMap.get("text"));
+            return elementFound;
+        }
+        if (propertyMap.get("xpath") != null && propertyMap.get("xpath").length() != 0) {
+            elementFound = findElementByXPath(propertyMap.get("xpath"));
+            return elementFound;
+        }
+        return null;
     }
 
     @Override

--- a/taps_to_cases/runner/src/main/java/com/microsoft/hydralab/t2c/runner/controller/EdgeDriverController.java
+++ b/taps_to_cases/runner/src/main/java/com/microsoft/hydralab/t2c/runner/controller/EdgeDriverController.java
@@ -1,14 +1,13 @@
 package com.microsoft.hydralab.t2c.runner.controller;
 
 import io.appium.java_client.windows.WindowsDriver;
-import org.jetbrains.annotations.Nullable;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.edge.EdgeDriver;
 import org.openqa.selenium.interactions.PointerInput;
 import org.openqa.selenium.interactions.Sequence;
 import org.slf4j.Logger;
 
-import java.awt.*;
+import java.awt.Toolkit;
 import java.awt.datatransfer.Clipboard;
 import java.awt.datatransfer.DataFlavor;
 import java.awt.datatransfer.StringSelection;
@@ -16,7 +15,6 @@ import java.awt.datatransfer.UnsupportedFlavorException;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.Arrays;
-import java.util.Map;
 
 public class EdgeDriverController extends BaseDriverController {
     EdgeDriver edgeDriver;
@@ -52,22 +50,10 @@ public class EdgeDriverController extends BaseDriverController {
     }
 
     @Override
-    public @Nullable WebElement findElementBy(Map<String, String> propertyMap) {
-        WebElement elementFound = null;
-        if (propertyMap.get("accessibilityId") != null && propertyMap.get("accessibilityId").length() != 0) {
-            elementFound = findElementByAccessibilityId(propertyMap.get("accessibilityId"));
-            return elementFound;
-        }
-        if (propertyMap.get("text") != null && propertyMap.get("text").length() != 0) {
-            elementFound = findElementByName(propertyMap.get("text"));
-            return elementFound;
-        }
-        if (propertyMap.get("xpath") != null && propertyMap.get("xpath").length() != 0) {
-            elementFound = findElementByXPath(propertyMap.get("xpath"));
-            return elementFound;
-        }
-        return null;
+    public String getPageSource() {
+        return "Windows page: \n" + windowsDriver.getPageSource() + "\n Edge source: " + edgeDriver.getPageSource();
     }
+
 
     @Override
     public void paste(WebElement webElement) {

--- a/taps_to_cases/runner/src/main/java/com/microsoft/hydralab/t2c/runner/controller/WindowsDriverController.java
+++ b/taps_to_cases/runner/src/main/java/com/microsoft/hydralab/t2c/runner/controller/WindowsDriverController.java
@@ -3,13 +3,12 @@
 package com.microsoft.hydralab.t2c.runner.controller;
 
 import io.appium.java_client.windows.WindowsDriver;
-import org.jetbrains.annotations.Nullable;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.interactions.PointerInput;
 import org.openqa.selenium.interactions.Sequence;
 import org.slf4j.Logger;
 
-import java.awt.*;
+import java.awt.Toolkit;
 import java.awt.datatransfer.Clipboard;
 import java.awt.datatransfer.DataFlavor;
 import java.awt.datatransfer.StringSelection;
@@ -17,7 +16,6 @@ import java.awt.datatransfer.UnsupportedFlavorException;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.Arrays;
-import java.util.Map;
 
 public class WindowsDriverController extends BaseDriverController {
     WindowsDriver windowsDriver;
@@ -61,22 +59,10 @@ public class WindowsDriverController extends BaseDriverController {
     }
 
     @Override
-    public @Nullable WebElement findElementBy(Map<String, String> propertyMap) {
-        WebElement elementFound = null;
-        if (propertyMap.get("accessibilityId") != null && propertyMap.get("accessibilityId").length() != 0) {
-            elementFound = findElementByAccessibilityId(propertyMap.get("accessibilityId"));
-            return elementFound;
-        }
-        if (propertyMap.get("text") != null && propertyMap.get("text").length() != 0) {
-            elementFound = findElementByName(propertyMap.get("text"));
-            return elementFound;
-        }
-        if (propertyMap.get("xpath") != null && propertyMap.get("xpath").length() != 0) {
-            elementFound = findElementByXPath(propertyMap.get("xpath"));
-            return elementFound;
-        }
-        return null;
+    public String getPageSource() {
+        return windowsDriver.getPageSource();
     }
+
 
     @Override
     public void paste(WebElement webElement) {

--- a/taps_to_cases/runner/src/main/java/com/microsoft/hydralab/t2c/runner/controller/WindowsDriverController.java
+++ b/taps_to_cases/runner/src/main/java/com/microsoft/hydralab/t2c/runner/controller/WindowsDriverController.java
@@ -3,6 +3,7 @@
 package com.microsoft.hydralab.t2c.runner.controller;
 
 import io.appium.java_client.windows.WindowsDriver;
+import org.jetbrains.annotations.Nullable;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.interactions.PointerInput;
 import org.openqa.selenium.interactions.Sequence;
@@ -16,6 +17,7 @@ import java.awt.datatransfer.UnsupportedFlavorException;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.Arrays;
+import java.util.Map;
 
 public class WindowsDriverController extends BaseDriverController {
     WindowsDriver windowsDriver;
@@ -56,6 +58,24 @@ public class WindowsDriverController extends BaseDriverController {
         StringSelection selection = new StringSelection(text);
         Clipboard clipboard = Toolkit.getDefaultToolkit().getSystemClipboard();
         clipboard.setContents(selection, null);
+    }
+
+    @Override
+    public @Nullable WebElement findElementBy(Map<String, String> propertyMap) {
+        WebElement elementFound = null;
+        if (propertyMap.get("accessibilityId") != null && propertyMap.get("accessibilityId").length() != 0) {
+            elementFound = findElementByAccessibilityId(propertyMap.get("accessibilityId"));
+            return elementFound;
+        }
+        if (propertyMap.get("text") != null && propertyMap.get("text").length() != 0) {
+            elementFound = findElementByName(propertyMap.get("text"));
+            return elementFound;
+        }
+        if (propertyMap.get("xpath") != null && propertyMap.get("xpath").length() != 0) {
+            elementFound = findElementByXPath(propertyMap.get("xpath"));
+            return elementFound;
+        }
+        return null;
     }
 
     @Override

--- a/taps_to_cases/runner/src/main/java/com/microsoft/hydralab/t2c/runner/elements/AndroidElementInfo.java
+++ b/taps_to_cases/runner/src/main/java/com/microsoft/hydralab/t2c/runner/elements/AndroidElementInfo.java
@@ -6,8 +6,6 @@ import com.alibaba.fastjson.annotation.JSONField;
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Map;
 
 public class AndroidElementInfo extends BaseElementInfo {
     private String index;
@@ -75,16 +73,6 @@ public class AndroidElementInfo extends BaseElementInfo {
         if(bounds != null){
             parseCoordinates(bounds);
         }
-    }
-
-    @Override
-    public Map<String, String> getSearchByProperties() {
-        Map<String, String> keyToVal = new HashMap<>();
-        keyToVal.put("accessibilityId", accessibilityId);
-        keyToVal.put("xpath", xpath);
-        keyToVal.put("text", text);
-        keyToVal.put("resource-id", resourceId);
-        return keyToVal;
     }
 
     public void parseCoordinates(String bounds){

--- a/taps_to_cases/runner/src/main/java/com/microsoft/hydralab/t2c/runner/elements/AndroidElementInfo.java
+++ b/taps_to_cases/runner/src/main/java/com/microsoft/hydralab/t2c/runner/elements/AndroidElementInfo.java
@@ -50,7 +50,7 @@ public class AndroidElementInfo extends BaseElementInfo {
                               String checked, String clickable, String enabled, String focusable, String focused, String long_clickable,
                               String password, String scrollable, String selected, String bounds, String displayed, String xpath,
                               String resourceId) {
-        super(contentDesc,xpath,text);
+        super(xpath);
         this.index = index;
         this.packageName = packageName;
         this.className = className;

--- a/taps_to_cases/runner/src/main/java/com/microsoft/hydralab/t2c/runner/elements/AndroidElementInfo.java
+++ b/taps_to_cases/runner/src/main/java/com/microsoft/hydralab/t2c/runner/elements/AndroidElementInfo.java
@@ -78,7 +78,7 @@ public class AndroidElementInfo extends BaseElementInfo {
     }
 
     @Override
-    public Map<String, String> getBasisSearchedBy() {
+    public Map<String, String> getSearchByProperties() {
         Map<String, String> keyToVal = new HashMap<>();
         keyToVal.put("accessibilityId", accessibilityId);
         keyToVal.put("xpath", xpath);

--- a/taps_to_cases/runner/src/main/java/com/microsoft/hydralab/t2c/runner/elements/AndroidElementInfo.java
+++ b/taps_to_cases/runner/src/main/java/com/microsoft/hydralab/t2c/runner/elements/AndroidElementInfo.java
@@ -2,103 +2,98 @@
 // Licensed under the MIT License.
 package com.microsoft.hydralab.t2c.runner.elements;
 
-import com.alibaba.fastjson.JSONObject;
+import com.alibaba.fastjson.annotation.JSONField;
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
 
 public class AndroidElementInfo extends BaseElementInfo {
     private String index;
+    @JSONField(name = "package")
     private String packageName;
+    @JSONField(name = "class")
     private String className;
     private String text;
-    private String content_desc;
+    @JSONField(name = "content_desc")
+    private String contentDesc;
     private String checkable;
     private String checked;
     private String clickable;
     private String enabled;
     private String focusable;
     private String focused;
-    private String long_clickable;
+    @JSONField(name = "long-clickable")
+    private String longClickable;
     private String password;
     private String scrollable;
     private String selected;
     private String bounds;
     private String displayed;
     private String xpath;
-    private Integer top;
-    private Integer left;
-    private Integer width;
-    private Integer height;
 
-    private Integer centerX;
+    @JSONField(serialize = false, deserialize = false)
+    private int top;
+    @JSONField(serialize = false, deserialize = false)
+    private int left;
+    @JSONField(serialize = false, deserialize = false)
+    private int width;
+    @JSONField(serialize = false, deserialize = false)
+    private int height;
+    @JSONField(serialize = false, deserialize = false)
+    private int centerX;
+    @JSONField(serialize = false, deserialize = false)
+    private int centerY;
+    @JSONField(name = "resource-id")
+    private String resourceId;
 
-    private Integer centerY;
-    public static AndroidElementInfo getAndroidElementFromJson(JSONObject elementInfo) {
-        String index = elementInfo.getString("index");
-        String packageName = elementInfo.getString("package");
-        String className = elementInfo.getString("class");
-        String text = elementInfo.getString("text");
-        String content_desc = elementInfo.getString("content-desc");
-        String checkable = elementInfo.getString("checkable");
-        String checked = elementInfo.getString("clickable");
-        String clickable = elementInfo.getString("clickable");
-        String enabled = elementInfo.getString("checked");
-        String focusable = elementInfo.getString("focusable");
-        String focused = elementInfo.getString("focused");
-        String long_clickable = elementInfo.getString("long-clickable");
-        String password = elementInfo.getString("password");
-        String scrollable = elementInfo.getString("scrollable");
-        String selected = elementInfo.getString("selected");
-        String bounds = elementInfo.getString("bounds");
-        String displayed = elementInfo.getString("display");
-        String xpath = elementInfo.getString("xpath");
-        Integer top = elementInfo.getInteger("top");
-        Integer left = elementInfo.getInteger("left");
-        Integer width = elementInfo.getInteger("width");
-        Integer height = elementInfo.getInteger("height");
-        Integer centerX = elementInfo.getInteger("centerX");
-        Integer centerY = elementInfo.getInteger("centerY");
-
-        return new AndroidElementInfo(index, packageName, className, text,
-                content_desc, checkable, checked, clickable, enabled, focusable, focused, long_clickable,
-                password, scrollable, selected, bounds, displayed, xpath, top, left, width, height, centerX, centerY);
-    }
-    public AndroidElementInfo(String index, String packageName, String className, String text, String content_desc, String checkable,
+    public AndroidElementInfo(String index, String packageName, String className, String text, String contentDesc, String checkable,
                               String checked, String clickable, String enabled, String focusable, String focused, String long_clickable,
                               String password, String scrollable, String selected, String bounds, String displayed, String xpath,
-                              Integer top, Integer left, Integer width, Integer height, Integer centerX, Integer centerY){
-        super(content_desc,xpath,text);
+                              String resourceId) {
+        super(contentDesc,xpath,text);
         this.index = index;
         this.packageName = packageName;
         this.className = className;
         this.text = text;
-        this.content_desc = content_desc;
+        this.contentDesc = contentDesc;
         this.checkable = checkable;
         this.checked = checked;
         this.clickable = clickable;
         this.enabled = enabled;
         this.focusable = focusable;
         this.focused = focused;
-        this.long_clickable = long_clickable;
+        this.longClickable = long_clickable;
         this.password = password;
         this.scrollable = scrollable;
         this.selected = selected;
         this.bounds = bounds;
         this.displayed = displayed;
         this.xpath = xpath;
+        this.resourceId = resourceId;
         if(bounds != null){
             parseCoordinates(bounds);
         }
     }
 
+    @Override
+    public Map<String, String> getBasisSearchedBy() {
+        Map<String, String> keyToVal = new HashMap<>();
+        keyToVal.put("accessibilityId", accessibilityId);
+        keyToVal.put("xpath", xpath);
+        keyToVal.put("text", text);
+        keyToVal.put("resource-id", resourceId);
+        return keyToVal;
+    }
+
     public void parseCoordinates(String bounds){
         String[] boundsArray = bounds.split("\\[|\\]|,");
         String[] validArr = Arrays.stream(boundsArray).filter(StringUtils::isNotEmpty).toArray(String[]::new);
-        Integer x1 = Integer.parseInt(validArr[0]);
-        Integer x2 = Integer.parseInt(validArr[2]);
-        Integer y1 = Integer.parseInt(validArr[1]);
-        Integer y2 = Integer.parseInt(validArr[3]);
+        int x1 = Integer.parseInt(validArr[0]);
+        int x2 = Integer.parseInt(validArr[2]);
+        int y1 = Integer.parseInt(validArr[1]);
+        int y2 = Integer.parseInt(validArr[3]);
         top = y1;
         left = x1;
         width = x2-x1;
@@ -119,8 +114,8 @@ public class AndroidElementInfo extends BaseElementInfo {
         return className;
     }
 
-    public String getContent_desc() {
-        return content_desc;
+    public String getContentDesc() {
+        return contentDesc;
     }
 
     public String getText(){
@@ -132,27 +127,80 @@ public class AndroidElementInfo extends BaseElementInfo {
         return xpath;
     }
 
-    public Integer getTop() {
+    public int getTop() {
         return top;
     }
 
-    public Integer getLeft() {
+    public int getLeft() {
         return left;
     }
 
-    public Integer getCenterX() {
+    public int getCenterX() {
         return centerX;
     }
 
-    public Integer getCenterY() {
+    public int getCenterY() {
         return centerY;
     }
 
-    public Integer getHeight() {
+    public int getHeight() {
         return height;
     }
 
-    public Integer getWidth() {
+    public int getWidth() {
         return width;
+    }
+
+    public String getResourceId() {
+        return resourceId;
+    }
+
+
+    public boolean isCheckable() {
+        return Boolean.parseBoolean(checkable);
+    }
+
+    public boolean isChecked() {
+        return Boolean.parseBoolean(checked);
+    }
+
+    public boolean isClickable() {
+        return Boolean.parseBoolean(clickable);
+    }
+
+    public boolean isEnabled() {
+        return Boolean.parseBoolean(enabled);
+    }
+
+    public boolean isFocusable() {
+        return Boolean.parseBoolean(focusable);
+    }
+
+    public boolean isFocused() {
+        return Boolean.parseBoolean(focused);
+    }
+
+    public boolean isLongClickable() {
+        return Boolean.parseBoolean(longClickable);
+    }
+
+    public boolean isPassword() {
+        return Boolean.parseBoolean(password);
+    }
+
+    public boolean isScrollable() {
+        return Boolean.parseBoolean(scrollable);
+    }
+
+    public boolean isSelected() {
+        return Boolean.parseBoolean(selected);
+    }
+
+    public String getBounds() {
+        return bounds;
+    }
+
+    public boolean isDisplayed() {
+        return Boolean.parseBoolean(displayed);
     }
 }

--- a/taps_to_cases/runner/src/main/java/com/microsoft/hydralab/t2c/runner/elements/AndroidElementInfo.java
+++ b/taps_to_cases/runner/src/main/java/com/microsoft/hydralab/t2c/runner/elements/AndroidElementInfo.java
@@ -75,7 +75,7 @@ public class AndroidElementInfo extends BaseElementInfo {
         }
     }
 
-    public void parseCoordinates(String bounds){
+    private void parseCoordinates(String bounds){
         String[] boundsArray = bounds.split("\\[|\\]|,");
         String[] validArr = Arrays.stream(boundsArray).filter(StringUtils::isNotEmpty).toArray(String[]::new);
         int x1 = Integer.parseInt(validArr[0]);

--- a/taps_to_cases/runner/src/main/java/com/microsoft/hydralab/t2c/runner/elements/BaseElementInfo.java
+++ b/taps_to_cases/runner/src/main/java/com/microsoft/hydralab/t2c/runner/elements/BaseElementInfo.java
@@ -7,10 +7,10 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
 import java.util.HashMap;
 import java.util.Map;
 
-public class BaseElementInfo {
-    private String accessibilityId;
-    private String xpath;
-    private String text;
+public abstract class BaseElementInfo {
+    protected final String accessibilityId;
+    protected final String xpath;
+    protected final String text;
 
     public BaseElementInfo(String accessibilityId, String xpath, String text) {
         this.accessibilityId = accessibilityId;
@@ -18,13 +18,7 @@ public class BaseElementInfo {
         this.text = text;
     }
 
-    public Map<String, String> getBasisSearchedBy() {
-        Map<String, String> keyToVal = new HashMap<>();
-        keyToVal.put("accessibilityId", accessibilityId);
-        keyToVal.put("xpath", xpath);
-        keyToVal.put("text", text);
-        return keyToVal;
-    }
+    public abstract Map<String, String> getBasisSearchedBy();
 
 
 

--- a/taps_to_cases/runner/src/main/java/com/microsoft/hydralab/t2c/runner/elements/BaseElementInfo.java
+++ b/taps_to_cases/runner/src/main/java/com/microsoft/hydralab/t2c/runner/elements/BaseElementInfo.java
@@ -4,8 +4,6 @@ package com.microsoft.hydralab.t2c.runner.elements;
 
 import org.apache.commons.lang3.builder.ToStringBuilder;
 
-import java.util.Map;
-
 public abstract class BaseElementInfo {
     protected final String accessibilityId;
     protected final String xpath;
@@ -16,9 +14,6 @@ public abstract class BaseElementInfo {
         this.xpath = xpath;
         this.text = text;
     }
-
-    public abstract Map<String, String> getSearchByProperties();
-
 
 
     public String getElementInfo(){

--- a/taps_to_cases/runner/src/main/java/com/microsoft/hydralab/t2c/runner/elements/BaseElementInfo.java
+++ b/taps_to_cases/runner/src/main/java/com/microsoft/hydralab/t2c/runner/elements/BaseElementInfo.java
@@ -5,14 +5,10 @@ package com.microsoft.hydralab.t2c.runner.elements;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 
 public abstract class BaseElementInfo {
-    protected final String accessibilityId;
     protected final String xpath;
-    protected final String text;
 
-    public BaseElementInfo(String accessibilityId, String xpath, String text) {
-        this.accessibilityId = accessibilityId;
+    public BaseElementInfo(String xpath) {
         this.xpath = xpath;
-        this.text = text;
     }
 
 
@@ -20,15 +16,9 @@ public abstract class BaseElementInfo {
         return ToStringBuilder.reflectionToString(this);
     }
 
-    public String getAccessibilityId() {
-        return accessibilityId;
-    }
 
     public String getXpath() {
         return xpath;
     }
 
-    public String getText() {
-        return text;
-    }
 }

--- a/taps_to_cases/runner/src/main/java/com/microsoft/hydralab/t2c/runner/elements/BaseElementInfo.java
+++ b/taps_to_cases/runner/src/main/java/com/microsoft/hydralab/t2c/runner/elements/BaseElementInfo.java
@@ -4,7 +4,6 @@ package com.microsoft.hydralab.t2c.runner.elements;
 
 import org.apache.commons.lang3.builder.ToStringBuilder;
 
-import java.util.HashMap;
 import java.util.Map;
 
 public abstract class BaseElementInfo {
@@ -18,11 +17,23 @@ public abstract class BaseElementInfo {
         this.text = text;
     }
 
-    public abstract Map<String, String> getBasisSearchedBy();
+    public abstract Map<String, String> getSearchByProperties();
 
 
 
     public String getElementInfo(){
         return ToStringBuilder.reflectionToString(this);
+    }
+
+    public String getAccessibilityId() {
+        return accessibilityId;
+    }
+
+    public String getXpath() {
+        return xpath;
+    }
+
+    public String getText() {
+        return text;
     }
 }

--- a/taps_to_cases/runner/src/main/java/com/microsoft/hydralab/t2c/runner/elements/WindowsElementInfo.java
+++ b/taps_to_cases/runner/src/main/java/com/microsoft/hydralab/t2c/runner/elements/WindowsElementInfo.java
@@ -4,9 +4,6 @@ package com.microsoft.hydralab.t2c.runner.elements;
 
 import org.apache.commons.lang3.builder.ToStringBuilder;
 
-import java.util.HashMap;
-import java.util.Map;
-
 public class WindowsElementInfo extends BaseElementInfo {
     private String AcceleratorKey;
     private String AccessKey;
@@ -73,15 +70,6 @@ public class WindowsElementInfo extends BaseElementInfo {
         this.xpath = xpath;
         this.centerX = Integer.parseInt(x)+Integer.parseInt(width)/2;
         this.centerY = Integer.parseInt(y)+Integer.parseInt(height)/2;
-    }
-
-    @Override
-    public Map<String, String> getSearchByProperties() {
-        Map<String, String> keyToVal = new HashMap<>();
-        keyToVal.put("accessibilityId", accessibilityId);
-        keyToVal.put("xpath", xpath);
-        keyToVal.put("text", text);
-        return keyToVal;
     }
 
     public String getElementInfo(){

--- a/taps_to_cases/runner/src/main/java/com/microsoft/hydralab/t2c/runner/elements/WindowsElementInfo.java
+++ b/taps_to_cases/runner/src/main/java/com/microsoft/hydralab/t2c/runner/elements/WindowsElementInfo.java
@@ -76,7 +76,7 @@ public class WindowsElementInfo extends BaseElementInfo {
     }
 
     @Override
-    public Map<String, String> getBasisSearchedBy() {
+    public Map<String, String> getSearchByProperties() {
         Map<String, String> keyToVal = new HashMap<>();
         keyToVal.put("accessibilityId", accessibilityId);
         keyToVal.put("xpath", xpath);

--- a/taps_to_cases/runner/src/main/java/com/microsoft/hydralab/t2c/runner/elements/WindowsElementInfo.java
+++ b/taps_to_cases/runner/src/main/java/com/microsoft/hydralab/t2c/runner/elements/WindowsElementInfo.java
@@ -4,6 +4,9 @@ package com.microsoft.hydralab.t2c.runner.elements;
 
 import org.apache.commons.lang3.builder.ToStringBuilder;
 
+import java.util.HashMap;
+import java.util.Map;
+
 public class WindowsElementInfo extends BaseElementInfo {
     private String AcceleratorKey;
     private String AccessKey;
@@ -70,6 +73,15 @@ public class WindowsElementInfo extends BaseElementInfo {
         this.xpath = xpath;
         this.centerX = Integer.parseInt(x)+Integer.parseInt(width)/2;
         this.centerY = Integer.parseInt(y)+Integer.parseInt(height)/2;
+    }
+
+    @Override
+    public Map<String, String> getBasisSearchedBy() {
+        Map<String, String> keyToVal = new HashMap<>();
+        keyToVal.put("accessibilityId", accessibilityId);
+        keyToVal.put("xpath", xpath);
+        keyToVal.put("text", text);
+        return keyToVal;
     }
 
     public String getElementInfo(){

--- a/taps_to_cases/runner/src/main/java/com/microsoft/hydralab/t2c/runner/elements/WindowsElementInfo.java
+++ b/taps_to_cases/runner/src/main/java/com/microsoft/hydralab/t2c/runner/elements/WindowsElementInfo.java
@@ -2,8 +2,6 @@
 // Licensed under the MIT License.
 package com.microsoft.hydralab.t2c.runner.elements;
 
-import org.apache.commons.lang3.builder.ToStringBuilder;
-
 public class WindowsElementInfo extends BaseElementInfo {
     private String AcceleratorKey;
     private String AccessKey;
@@ -41,7 +39,7 @@ public class WindowsElementInfo extends BaseElementInfo {
                               String isPassword, String isRequiredForForm, String itemStatus, String itemType,
                               String localizedControlType, String name, String orientation, String processId,
                               String runtimeId, String x, String y, String width, String height, String xpath){
-        super(automationId,xpath,name);
+        super(xpath);
         this.AcceleratorKey = acceleratorKey;
         this.AccessKey = accessKey;
         this.AutomationId = automationId;
@@ -72,9 +70,6 @@ public class WindowsElementInfo extends BaseElementInfo {
         this.centerY = Integer.parseInt(y)+Integer.parseInt(height)/2;
     }
 
-    public String getElementInfo(){
-        return ToStringBuilder.reflectionToString(this);
-    }
     public String getAcceleratorKey() {
         return AcceleratorKey;
     }

--- a/taps_to_cases/runner/src/main/java/com/microsoft/hydralab/t2c/runner/finder/AndroidElementFinder.java
+++ b/taps_to_cases/runner/src/main/java/com/microsoft/hydralab/t2c/runner/finder/AndroidElementFinder.java
@@ -16,16 +16,16 @@ public class AndroidElementFinder implements ElementFinder<AndroidElementInfo> {
     @Override
     public WebElement findElement(AndroidElementInfo elementInfo) {
         WebElement elementFound;
-        if (!Strings.isNullOrEmpty(elementInfo.getContentDesc())) {
-            elementFound = driverController.findElementByAccessibilityId(elementInfo.getContentDesc());
+
+        if (!Strings.isNullOrEmpty(elementInfo.getResourceId())) {
+            elementFound = driverController.findElementById(elementInfo.getResourceId());
             if (elementFound != null) {
                 return elementFound;
             }
         }
 
-
-        if (!Strings.isNullOrEmpty(elementInfo.getResourceId())) {
-            elementFound = driverController.findElementById(elementInfo.getResourceId());
+        if (!Strings.isNullOrEmpty(elementInfo.getContentDesc())) {
+            elementFound = driverController.findElementByAccessibilityId(elementInfo.getContentDesc());
             if (elementFound != null) {
                 return elementFound;
             }

--- a/taps_to_cases/runner/src/main/java/com/microsoft/hydralab/t2c/runner/finder/AndroidElementFinder.java
+++ b/taps_to_cases/runner/src/main/java/com/microsoft/hydralab/t2c/runner/finder/AndroidElementFinder.java
@@ -9,7 +9,7 @@ public class AndroidElementFinder implements ElementFinder<AndroidElementInfo> {
 
     private final BaseDriverController driverController;
 
-    AndroidElementFinder(BaseDriverController driverController) {
+    public AndroidElementFinder(BaseDriverController driverController) {
         this.driverController = driverController;
     }
 

--- a/taps_to_cases/runner/src/main/java/com/microsoft/hydralab/t2c/runner/finder/AndroidElementFinder.java
+++ b/taps_to_cases/runner/src/main/java/com/microsoft/hydralab/t2c/runner/finder/AndroidElementFinder.java
@@ -1,0 +1,47 @@
+package com.microsoft.hydralab.t2c.runner.finder;
+
+import com.google.common.base.Strings;
+import com.microsoft.hydralab.t2c.runner.controller.BaseDriverController;
+import com.microsoft.hydralab.t2c.runner.elements.AndroidElementInfo;
+import org.openqa.selenium.WebElement;
+
+public class AndroidElementFinder implements ElementFinder<AndroidElementInfo> {
+
+    private final BaseDriverController driverController;
+
+    AndroidElementFinder(BaseDriverController driverController) {
+        this.driverController = driverController;
+    }
+
+    @Override
+    public WebElement findElement(AndroidElementInfo elementInfo) {
+        WebElement elementFound;
+        if (!Strings.isNullOrEmpty(elementInfo.getAccessibilityId())) {
+            elementFound = driverController.findElementByAccessibilityId(elementInfo.getAccessibilityId());
+            if (elementFound != null) {
+                return elementFound;
+            }
+        }
+        if (!Strings.isNullOrEmpty(elementInfo.getXpath())) {
+            elementFound = driverController.findElementByXPath(elementInfo.getXpath());
+            if (elementFound != null) {
+                return elementFound;
+            }
+        }
+
+        if (!Strings.isNullOrEmpty(elementInfo.getResourceId())) {
+            elementFound = driverController.findElementById(elementInfo.getResourceId());
+            if (elementFound != null) {
+                return elementFound;
+            }
+        }
+
+        if (!Strings.isNullOrEmpty(elementInfo.getText())) {
+            elementFound = driverController.findElementByText(elementInfo.getText());
+            if (elementFound != null) {
+                return elementFound;
+            }
+        }
+        return null;
+    }
+}

--- a/taps_to_cases/runner/src/main/java/com/microsoft/hydralab/t2c/runner/finder/AndroidElementFinder.java
+++ b/taps_to_cases/runner/src/main/java/com/microsoft/hydralab/t2c/runner/finder/AndroidElementFinder.java
@@ -16,18 +16,13 @@ public class AndroidElementFinder implements ElementFinder<AndroidElementInfo> {
     @Override
     public WebElement findElement(AndroidElementInfo elementInfo) {
         WebElement elementFound;
-        if (!Strings.isNullOrEmpty(elementInfo.getAccessibilityId())) {
-            elementFound = driverController.findElementByAccessibilityId(elementInfo.getAccessibilityId());
+        if (!Strings.isNullOrEmpty(elementInfo.getContentDesc())) {
+            elementFound = driverController.findElementByAccessibilityId(elementInfo.getContentDesc());
             if (elementFound != null) {
                 return elementFound;
             }
         }
-        if (!Strings.isNullOrEmpty(elementInfo.getXpath())) {
-            elementFound = driverController.findElementByXPath(elementInfo.getXpath());
-            if (elementFound != null) {
-                return elementFound;
-            }
-        }
+
 
         if (!Strings.isNullOrEmpty(elementInfo.getResourceId())) {
             elementFound = driverController.findElementById(elementInfo.getResourceId());
@@ -38,6 +33,13 @@ public class AndroidElementFinder implements ElementFinder<AndroidElementInfo> {
 
         if (!Strings.isNullOrEmpty(elementInfo.getText())) {
             elementFound = driverController.findElementByText(elementInfo.getText());
+            if (elementFound != null) {
+                return elementFound;
+            }
+        }
+
+        if (!Strings.isNullOrEmpty(elementInfo.getXpath())) {
+            elementFound = driverController.findElementByXPath(elementInfo.getXpath());
             if (elementFound != null) {
                 return elementFound;
             }

--- a/taps_to_cases/runner/src/main/java/com/microsoft/hydralab/t2c/runner/finder/EdgeElementFinder.java
+++ b/taps_to_cases/runner/src/main/java/com/microsoft/hydralab/t2c/runner/finder/EdgeElementFinder.java
@@ -9,7 +9,7 @@ public class EdgeElementFinder implements ElementFinder<EdgeElementInfo>  {
 
     private final BaseDriverController driverController;
 
-    EdgeElementFinder(BaseDriverController driverController) {
+    public EdgeElementFinder(BaseDriverController driverController) {
         this.driverController = driverController;
     }
 

--- a/taps_to_cases/runner/src/main/java/com/microsoft/hydralab/t2c/runner/finder/EdgeElementFinder.java
+++ b/taps_to_cases/runner/src/main/java/com/microsoft/hydralab/t2c/runner/finder/EdgeElementFinder.java
@@ -16,21 +16,21 @@ public class EdgeElementFinder implements ElementFinder<EdgeElementInfo>  {
     @Override
     public WebElement findElement(EdgeElementInfo elementInfo) {
         WebElement elementFound;
-        if (!Strings.isNullOrEmpty(elementInfo.getAccessibilityId())) {
-            elementFound = driverController.findElementByAccessibilityId(elementInfo.getAccessibilityId());
+        if (!Strings.isNullOrEmpty(elementInfo.getAutomationId())) {
+            elementFound = driverController.findElementByAccessibilityId(elementInfo.getAutomationId());
             if (elementFound != null) {
                 return elementFound;
             }
         }
-        if (!Strings.isNullOrEmpty(elementInfo.getXpath())) {
-            elementFound = driverController.findElementByXPath(elementInfo.getXpath());
+        if (!Strings.isNullOrEmpty(elementInfo.getName())) {
+            elementFound = driverController.findElementById(elementInfo.getName());
             if (elementFound != null) {
                 return elementFound;
             }
         }
 
-        if (!Strings.isNullOrEmpty(elementInfo.getText())) {
-            elementFound = driverController.findElementByText(elementInfo.getText());
+        if (!Strings.isNullOrEmpty(elementInfo.getXpath())) {
+            elementFound = driverController.findElementByXPath(elementInfo.getXpath());
             if (elementFound != null) {
                 return elementFound;
             }

--- a/taps_to_cases/runner/src/main/java/com/microsoft/hydralab/t2c/runner/finder/EdgeElementFinder.java
+++ b/taps_to_cases/runner/src/main/java/com/microsoft/hydralab/t2c/runner/finder/EdgeElementFinder.java
@@ -1,0 +1,40 @@
+package com.microsoft.hydralab.t2c.runner.finder;
+
+import com.google.common.base.Strings;
+import com.microsoft.hydralab.t2c.runner.controller.BaseDriverController;
+import com.microsoft.hydralab.t2c.runner.elements.EdgeElementInfo;
+import org.openqa.selenium.WebElement;
+
+public class EdgeElementFinder implements ElementFinder<EdgeElementInfo>  {
+
+    private final BaseDriverController driverController;
+
+    EdgeElementFinder(BaseDriverController driverController) {
+        this.driverController = driverController;
+    }
+
+    @Override
+    public WebElement findElement(EdgeElementInfo elementInfo) {
+        WebElement elementFound;
+        if (!Strings.isNullOrEmpty(elementInfo.getAccessibilityId())) {
+            elementFound = driverController.findElementByAccessibilityId(elementInfo.getAccessibilityId());
+            if (elementFound != null) {
+                return elementFound;
+            }
+        }
+        if (!Strings.isNullOrEmpty(elementInfo.getXpath())) {
+            elementFound = driverController.findElementByXPath(elementInfo.getXpath());
+            if (elementFound != null) {
+                return elementFound;
+            }
+        }
+
+        if (!Strings.isNullOrEmpty(elementInfo.getText())) {
+            elementFound = driverController.findElementByText(elementInfo.getText());
+            if (elementFound != null) {
+                return elementFound;
+            }
+        }
+        return null;
+    }
+}

--- a/taps_to_cases/runner/src/main/java/com/microsoft/hydralab/t2c/runner/finder/ElementFinder.java
+++ b/taps_to_cases/runner/src/main/java/com/microsoft/hydralab/t2c/runner/finder/ElementFinder.java
@@ -1,0 +1,10 @@
+package com.microsoft.hydralab.t2c.runner.finder;
+
+import com.microsoft.hydralab.t2c.runner.elements.BaseElementInfo;
+import org.openqa.selenium.WebElement;
+
+public interface ElementFinder<T extends BaseElementInfo> {
+
+    WebElement findElement(T elementInfo);
+
+}

--- a/taps_to_cases/runner/src/main/java/com/microsoft/hydralab/t2c/runner/finder/ElementFinderFactory.java
+++ b/taps_to_cases/runner/src/main/java/com/microsoft/hydralab/t2c/runner/finder/ElementFinderFactory.java
@@ -1,0 +1,51 @@
+package com.microsoft.hydralab.t2c.runner.finder;
+
+import com.microsoft.hydralab.t2c.runner.controller.AndroidDriverController;
+import com.microsoft.hydralab.t2c.runner.controller.BaseDriverController;
+import com.microsoft.hydralab.t2c.runner.controller.EdgeDriverController;
+import com.microsoft.hydralab.t2c.runner.controller.WindowsDriverController;
+import com.microsoft.hydralab.t2c.runner.elements.BaseElementInfo;
+import org.jetbrains.annotations.NotNull;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.HashMap;
+import java.util.Map;
+
+public class ElementFinderFactory {
+
+    private static final Map<Class<?>, Class<?>> registryMap = new HashMap<>();
+
+    static {
+        registryMap.put(AndroidDriverController.class, AndroidElementFinder.class);
+        registryMap.put(EdgeDriverController.class, EdgeElementFinder.class);
+        registryMap.put(WindowsDriverController.class, WindowsElementFinder.class);
+    }
+
+    /**
+     * Register your element finder in the factory, by default we provide {@link AndroidElementFinder},
+     * {@link EdgeElementFinder} and {@link WindowsElementFinder}
+     * @param controller see {@link BaseDriverController}
+     * @param finder see {@link ElementFinder}
+     */
+    public static void registerFinder(Class<? extends BaseDriverController> controller, Class<? extends ElementFinder<? extends BaseElementInfo>> finder) {
+        registryMap.put(controller, finder);
+    }
+
+    @SuppressWarnings("unchecked")
+    @NotNull
+    public static <T extends BaseElementInfo> ElementFinder<T> createElementFinder(BaseDriverController driverController) {
+        Class<?> finderClz = registryMap.get(driverController.getClass());
+        if (finderClz != null){
+            try {
+                return (ElementFinder<T>) finderClz.getDeclaredConstructor(BaseDriverController.class).newInstance(driverController);
+            } catch (InstantiationException | InvocationTargetException e) {
+                throw new RuntimeException(e);
+            } catch(IllegalAccessException e) {
+                throw new UnsupportedOperationException("ElementFinder must be a public class, exception: " + e.getMessage());
+            } catch (NoSuchMethodException e) {
+               throw new UnsupportedOperationException("ElementFinder must have a constructor with param BaseDriverController");
+            }
+        }
+        throw new UnsupportedOperationException("Unsupported driver controller!");
+    }
+}

--- a/taps_to_cases/runner/src/main/java/com/microsoft/hydralab/t2c/runner/finder/WindowsElementFinder.java
+++ b/taps_to_cases/runner/src/main/java/com/microsoft/hydralab/t2c/runner/finder/WindowsElementFinder.java
@@ -1,0 +1,40 @@
+package com.microsoft.hydralab.t2c.runner.finder;
+
+import com.google.common.base.Strings;
+import com.microsoft.hydralab.t2c.runner.controller.BaseDriverController;
+import com.microsoft.hydralab.t2c.runner.elements.WindowsElementInfo;
+import org.openqa.selenium.WebElement;
+
+public class WindowsElementFinder implements ElementFinder<WindowsElementInfo> {
+
+    private final BaseDriverController driverController;
+
+    WindowsElementFinder(BaseDriverController driverController) {
+        this.driverController = driverController;
+    }
+
+    @Override
+    public WebElement findElement(WindowsElementInfo elementInfo) {
+        WebElement elementFound;
+        if (!Strings.isNullOrEmpty(elementInfo.getAccessibilityId())) {
+            elementFound = driverController.findElementByAccessibilityId(elementInfo.getAccessibilityId());
+            if (elementFound != null) {
+                return elementFound;
+            }
+        }
+        if (!Strings.isNullOrEmpty(elementInfo.getXpath())) {
+            elementFound = driverController.findElementByXPath(elementInfo.getXpath());
+            if (elementFound != null) {
+                return elementFound;
+            }
+        }
+
+        if (!Strings.isNullOrEmpty(elementInfo.getText())) {
+            elementFound = driverController.findElementByText(elementInfo.getText());
+            if (elementFound != null) {
+                return elementFound;
+            }
+        }
+        return null;
+    }
+}

--- a/taps_to_cases/runner/src/main/java/com/microsoft/hydralab/t2c/runner/finder/WindowsElementFinder.java
+++ b/taps_to_cases/runner/src/main/java/com/microsoft/hydralab/t2c/runner/finder/WindowsElementFinder.java
@@ -9,7 +9,7 @@ public class WindowsElementFinder implements ElementFinder<WindowsElementInfo> {
 
     private final BaseDriverController driverController;
 
-    WindowsElementFinder(BaseDriverController driverController) {
+    public WindowsElementFinder(BaseDriverController driverController) {
         this.driverController = driverController;
     }
 

--- a/taps_to_cases/runner/src/main/java/com/microsoft/hydralab/t2c/runner/finder/WindowsElementFinder.java
+++ b/taps_to_cases/runner/src/main/java/com/microsoft/hydralab/t2c/runner/finder/WindowsElementFinder.java
@@ -16,21 +16,21 @@ public class WindowsElementFinder implements ElementFinder<WindowsElementInfo> {
     @Override
     public WebElement findElement(WindowsElementInfo elementInfo) {
         WebElement elementFound;
-        if (!Strings.isNullOrEmpty(elementInfo.getAccessibilityId())) {
-            elementFound = driverController.findElementByAccessibilityId(elementInfo.getAccessibilityId());
+        if (!Strings.isNullOrEmpty(elementInfo.getAutomationId())) {
+            elementFound = driverController.findElementByAccessibilityId(elementInfo.getAutomationId());
             if (elementFound != null) {
                 return elementFound;
             }
         }
-        if (!Strings.isNullOrEmpty(elementInfo.getXpath())) {
-            elementFound = driverController.findElementByXPath(elementInfo.getXpath());
+        if (!Strings.isNullOrEmpty(elementInfo.getName())) {
+            elementFound = driverController.findElementById(elementInfo.getName());
             if (elementFound != null) {
                 return elementFound;
             }
         }
 
-        if (!Strings.isNullOrEmpty(elementInfo.getText())) {
-            elementFound = driverController.findElementByText(elementInfo.getText());
+        if (!Strings.isNullOrEmpty(elementInfo.getXpath())) {
+            elementFound = driverController.findElementByXPath(elementInfo.getXpath());
             if (elementFound != null) {
                 return elementFound;
             }

--- a/taps_to_cases/runner/src/test/java/com/microsoft/hydralab/t2c/runner/MockDriverT2CTest.java
+++ b/taps_to_cases/runner/src/test/java/com/microsoft/hydralab/t2c/runner/MockDriverT2CTest.java
@@ -4,11 +4,21 @@
 package com.microsoft.hydralab.t2c.runner;
 
 import com.microsoft.hydralab.t2c.runner.controller.BaseDriverController;
+import com.microsoft.hydralab.t2c.runner.elements.BaseElementInfo;
+import com.microsoft.hydralab.t2c.runner.finder.ElementFinder;
+import com.microsoft.hydralab.t2c.runner.finder.ElementFinderFactory;
 import io.appium.java_client.android.nativekey.AndroidKey;
 import org.jetbrains.annotations.Nullable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.openqa.selenium.*;
+import org.openqa.selenium.By;
+import org.openqa.selenium.Dimension;
+import org.openqa.selenium.OutputType;
+import org.openqa.selenium.Point;
+import org.openqa.selenium.Rectangle;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebDriverException;
+import org.openqa.selenium.WebElement;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -33,6 +43,7 @@ public class MockDriverT2CTest {
         testInfo = t2CJsonParser.parseJsonFile(filePath);
         T2CAppiumUtils.setSelfTesting(true);
         getDriversMap(testInfo.getDrivers());
+        ElementFinderFactory.registerFinder(MockDriverController.class, MockElementFinder.class);
 
     }
 
@@ -49,6 +60,21 @@ public class MockDriverT2CTest {
         for (ActionInfo actionInfo : caseList) {
             BaseDriverController driverController = driverControllerMap.get(actionInfo.getDriverId());
             T2CAppiumUtils.doAction(driverController, actionInfo, logger);
+        }
+    }
+
+    public static class MockElementFinder implements ElementFinder<BaseElementInfo> {
+
+        private final BaseDriverController driverController;
+
+        public MockElementFinder(BaseDriverController driverController) {
+            this.driverController = driverController;
+        }
+
+        @Override
+        public WebElement findElement(BaseElementInfo elementInfo) {
+            driverController.findElementByXPath(elementInfo.getXpath());
+            return new MockElement();
         }
     }
 
@@ -152,16 +178,23 @@ public class MockDriverT2CTest {
             return new MockElement();
         }
 
-        public WebElement findElementByName(String name) {
+        public WebElement findElementByText(String text) {
             logger.info("Called " + currentMethodName());
             return new MockElement();
         }
 
         @Override
-        public @Nullable WebElement findElementBy(Map<String, String> propertyMap) {
-            logger.info("FindElementBy, {}", propertyMap.toString());
+        public @Nullable WebElement findElementById(String id) {
+            logger.info("Called " + currentMethodName());
             return new MockElement();
         }
+
+        @Override
+        public String getPageSource() {
+            logger.info("Called " + currentMethodName());
+            return "foo";
+        }
+
 
         public void copy(WebElement webElement) {
             logger.info("Called " + currentMethodName());

--- a/taps_to_cases/runner/src/test/java/com/microsoft/hydralab/t2c/runner/MockDriverT2CTest.java
+++ b/taps_to_cases/runner/src/test/java/com/microsoft/hydralab/t2c/runner/MockDriverT2CTest.java
@@ -5,6 +5,7 @@ package com.microsoft.hydralab.t2c.runner;
 
 import com.microsoft.hydralab.t2c.runner.controller.BaseDriverController;
 import io.appium.java_client.android.nativekey.AndroidKey;
+import org.jetbrains.annotations.Nullable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.*;
@@ -153,6 +154,12 @@ public class MockDriverT2CTest {
 
         public WebElement findElementByName(String name) {
             logger.info("Called " + currentMethodName());
+            return new MockElement();
+        }
+
+        @Override
+        public @Nullable WebElement findElementBy(Map<String, String> propertyMap) {
+            logger.info("FindElementBy, {}", propertyMap.toString());
             return new MockElement();
         }
 

--- a/taps_to_cases/runner/src/test/java/com/microsoft/hydralab/t2c/runner/SampleT2CTest.java
+++ b/taps_to_cases/runner/src/test/java/com/microsoft/hydralab/t2c/runner/SampleT2CTest.java
@@ -96,9 +96,7 @@ public class SampleT2CTest {
         for (ActionInfo actionInfo : caseList) {
             BaseDriverController driverController = driverControllerMap.get(actionInfo.getDriverId());
             System.out.println(actionInfo.getDriverId());
-            if (driverController.webDriver != null) {
-                T2CAppiumUtils.doAction(driverController, actionInfo, logger);
-            }
+            T2CAppiumUtils.doAction(driverController, actionInfo, logger);
         }
     }
 


### PR DESCRIPTION
# Goal
1. Following best practice of FastJson, annotate `AndroidElementInfo`
2. `BaseDriverController` should not expose any details inside, for example access to `webDriver` is not good to me.
3. Refactor `findElement` method with factory pattern, support dynamic registration and default factories of current existing controllers.
4. In this PR, we minimize the change in the finder package when changes on element search, no code changes should happen in controller classes, controller should only be responsible for decoration of `WebDriver` (Our `drivercontroller` is a decoration of `WebDriver`
5. In this PR, `ElementInfo` will not be aware of any info about how to find itself in page, which is not its responsibility. They are pure POJO classes.