### PR TITLE
Fix: ADO plugin report url can't redirect

### DIFF
--- a/vsts_extension/Tasks/HydraLabDeployTest/hydra-lab-deploy-test.ts
+++ b/vsts_extension/Tasks/HydraLabDeployTest/hydra-lab-deploy-test.ts
@@ -333,7 +333,7 @@ async function run() {
         }
 
         const testReportUrl: URL = new URL(HydraLabAPIConfig.Path.testPortalTaskInfoPath, HydraLabAPIConfig.serviceEndpointUrl);
-        testReportUrl.searchParams.append('redirectUrl', path.join('/info/task/', runningTest.id));
+        testReportUrl.searchParams.append('redirectUrl', `/info/task/${runningTest.id}`);
 
         const StringBuilder = require("string-builder");
         const mdBuilder: any = new StringBuilder();

--- a/vsts_extension/Tasks/HydraLabDeployTest/task.json
+++ b/vsts_extension/Tasks/HydraLabDeployTest/task.json
@@ -15,7 +15,7 @@
     "version": {
         "Major": 2,
         "Minor": 0,
-        "Patch": 12
+        "Patch": 13
     },
     "instanceNameFormat": "Deploy Tests of ${pkgName} to HydraLab",
     "inputs": [

--- a/vsts_extension/vss-extension.json
+++ b/vsts_extension/vss-extension.json
@@ -2,7 +2,7 @@
     "manifestVersion": 1,
     "id": "hydra-lab",
     "name": "Hydra Lab",
-    "version": "2.0.12",
+    "version": "2.0.13",
     "publisher": "",
     "public": true,
     "targets": [


### PR DESCRIPTION
Fix: ADO plugin report url can't redirect