### PR TITLE
[Perf] Fix the compatibility issue that WindowsBatteryInpector.ps1 cannot be executed with Runtime class

### DIFF
--- a/common/src/main/java/com/microsoft/hydralab/common/util/MachineInfoUtils.java
+++ b/common/src/main/java/com/microsoft/hydralab/common/util/MachineInfoUtils.java
@@ -44,6 +44,7 @@ public class MachineInfoUtils {
                 IOUtils.copy(Objects.requireNonNull(resourceAsStream), out);
                 out.close();
             } catch (IOException e) {
+                classLogger.error("Failed to find app handler script", e);
                 return false;
             }
         }

--- a/common/src/main/java/com/microsoft/hydralab/common/util/MachineInfoUtils.java
+++ b/common/src/main/java/com/microsoft/hydralab/common/util/MachineInfoUtils.java
@@ -2,10 +2,21 @@
 // Licensed under the MIT License.
 package com.microsoft.hydralab.common.util;
 
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.*;
 import java.util.Locale;
+import java.util.Objects;
 import java.util.Properties;
 
 public class MachineInfoUtils {
+
+    protected static Logger classLogger = LoggerFactory.getLogger(MachineInfoUtils.class);
+
+    private final static String DETECT_WINDOWS_LAPTOP_SCRIPT_NAME = "DetectWindowsLaptop.ps1";
 
     public static boolean isOnMacOS() {
         Properties props = System.getProperties();
@@ -17,6 +28,28 @@ public class MachineInfoUtils {
         Properties props = System.getProperties();
         String osName = props.getProperty("os.name");
         return osName.toLowerCase(Locale.US).contains("windows");
+    }
+
+    public static boolean isOnWindowsLaptop() {
+        if (!isOnWindows()) {
+            return false;
+        }
+
+        File SCRIPT_FILE = new File(DETECT_WINDOWS_LAPTOP_SCRIPT_NAME);
+        if (!SCRIPT_FILE.exists()) {
+            try {
+                InputStream resourceAsStream =
+                        FileUtils.class.getClassLoader().getResourceAsStream(DETECT_WINDOWS_LAPTOP_SCRIPT_NAME);
+                OutputStream out = new FileOutputStream(SCRIPT_FILE);
+                IOUtils.copy(Objects.requireNonNull(resourceAsStream), out);
+                out.close();
+            } catch (IOException e) {
+                return false;
+            }
+        }
+
+        String result = ShellUtils.execLocalCommandWithResult(SCRIPT_FILE.getAbsolutePath(), classLogger);
+        return result != null && result.equalsIgnoreCase("Yes");
     }
 
     public static String getCountryNameFromCode(String code) {

--- a/common/src/main/java/com/microsoft/hydralab/performance/inspectors/WindowsBatteryInspector.java
+++ b/common/src/main/java/com/microsoft/hydralab/performance/inspectors/WindowsBatteryInspector.java
@@ -9,10 +9,13 @@ import com.microsoft.hydralab.common.util.TimeUtils;
 import com.microsoft.hydralab.performance.PerformanceInspection;
 import com.microsoft.hydralab.performance.PerformanceInspectionResult;
 import com.microsoft.hydralab.performance.PerformanceInspector;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.File;
+import java.io.*;
+import java.util.Objects;
 
 /**
  * WindowsBatteryInspector is only suitable for the Windows devices with battery,
@@ -30,13 +33,29 @@ import java.io.File;
  */
 public class WindowsBatteryInspector implements PerformanceInspector {
     private final static String RAW_RESULT_FILE_NAME_FORMAT = "%s_%s.csv";
-    private final static String COMMAND_FORMAT = "Start-Process -FilePath Powershell.exe -Verb RunAs -ArgumentList " +
-            "'-command \"powercfg /srumutil /OUTPUT %s /CSV \"'";
+    private final static String SCRIPT_NAME = "WindowsBatteryInspector.ps1";
+    private final static File SCRIPT_FILE = new File(SCRIPT_NAME);
+    private final static String PARAMETER_FORMAT = " -output %s";
 
     protected Logger classLogger = LoggerFactory.getLogger(getClass());
 
+    public void initializeIfNeeded(PerformanceInspection performanceInspection) {
+        if (!SCRIPT_FILE.exists()) {
+            try {
+                InputStream resourceAsStream = FileUtils.class.getClassLoader().getResourceAsStream(SCRIPT_NAME);
+                OutputStream out = new FileOutputStream(SCRIPT_FILE);
+                IOUtils.copy(Objects.requireNonNull(resourceAsStream), out);
+                out.close();
+            } catch (IOException e) {
+                classLogger.error("Failed to find app handler script", e);
+            }
+        }
+    }
+
     @Override
     public PerformanceInspectionResult inspect(PerformanceInspection performanceInspection) {
+        initializeIfNeeded(performanceInspection);
+
         ITestRun testRun = TestRunThreadContext.getTestRun();
         if (testRun == null)
         {
@@ -46,7 +65,8 @@ public class WindowsBatteryInspector implements PerformanceInspector {
 
         File rawResultFile = new File(performanceInspection.resultFolder,
                 String.format(RAW_RESULT_FILE_NAME_FORMAT, getClass().getSimpleName(), TimeUtils.getTimestampForFilename()));
-        Process process = ShellUtils.execLocalCommand(String.format(COMMAND_FORMAT, rawResultFile), false, classLogger);
+        Process process = ShellUtils.execLocalCommand(SCRIPT_FILE.getAbsolutePath() +
+                String.format(PARAMETER_FORMAT, rawResultFile), false, classLogger);
         PerformanceInspectionResult result = new PerformanceInspectionResult(rawResultFile, performanceInspection);
 
         try {

--- a/common/src/main/java/com/microsoft/hydralab/performance/inspectors/WindowsBatteryInspector.java
+++ b/common/src/main/java/com/microsoft/hydralab/performance/inspectors/WindowsBatteryInspector.java
@@ -26,10 +26,10 @@ import java.util.Objects;
  * the elevation process to block the testing. There is a workaround to disable the UAC dialog by setting "Never notify"
  * in the UAC settings panel.
  *
- * TODO:
- * Need to verify if the agent configured with elevated privileges can bypass the UAC popup without changing the UAC
- * configuration.
- * Add a new method in ShellUtils to run the admin command if the TODO is not feasible.
+ * Prerequisites:
+ * 1. Requires a Windows device with a battery, such as a laptop
+ * 2. Need to disable UAC popup manually since the elevated privileges is required which would blocking the performance
+ * testing.
  */
 public class WindowsBatteryInspector implements PerformanceInspector {
     private final static String RAW_RESULT_FILE_NAME_FORMAT = "%s_%s.csv";

--- a/common/src/main/java/com/microsoft/hydralab/performance/inspectors/WindowsBatteryInspector.java
+++ b/common/src/main/java/com/microsoft/hydralab/performance/inspectors/WindowsBatteryInspector.java
@@ -4,6 +4,7 @@ package com.microsoft.hydralab.performance.inspectors;
 
 import com.microsoft.hydralab.agent.runner.ITestRun;
 import com.microsoft.hydralab.agent.runner.TestRunThreadContext;
+import com.microsoft.hydralab.common.util.MachineInfoUtils;
 import com.microsoft.hydralab.common.util.ShellUtils;
 import com.microsoft.hydralab.common.util.TimeUtils;
 import com.microsoft.hydralab.performance.PerformanceInspection;
@@ -54,6 +55,10 @@ public class WindowsBatteryInspector implements PerformanceInspector {
 
     @Override
     public PerformanceInspectionResult inspect(PerformanceInspection performanceInspection) {
+        if (!MachineInfoUtils.isOnWindowsLaptop()) {
+            classLogger.error("Windows battery test must be run on Windows Laptop!");
+            return null;
+        }
         initializeIfNeeded(performanceInspection);
 
         ITestRun testRun = TestRunThreadContext.getTestRun();

--- a/common/src/main/java/com/microsoft/hydralab/performance/parsers/WindowsBatteryResultParser.java
+++ b/common/src/main/java/com/microsoft/hydralab/performance/parsers/WindowsBatteryResultParser.java
@@ -44,6 +44,7 @@ public class WindowsBatteryResultParser implements PerformanceResultParser {
     @Override
     public PerformanceTestResult parse(PerformanceTestResult performanceTestResult) {
         try {
+            // Wait 20 seconds for the results to be completely written to the hard disk.
             Thread.sleep(20 * 1000);
         } catch (InterruptedException e) {
             throw new RuntimeException(e);

--- a/common/src/main/java/com/microsoft/hydralab/performance/parsers/WindowsBatteryResultParser.java
+++ b/common/src/main/java/com/microsoft/hydralab/performance/parsers/WindowsBatteryResultParser.java
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 package com.microsoft.hydralab.performance.parsers;
 
+import com.microsoft.hydralab.common.util.MachineInfoUtils;
 import com.microsoft.hydralab.performance.Entity.WindowsBatteryParsedData;
 import com.microsoft.hydralab.performance.PerformanceInspectionResult;
 import com.microsoft.hydralab.performance.PerformanceResultParser;
@@ -43,6 +44,11 @@ public class WindowsBatteryResultParser implements PerformanceResultParser {
 
     @Override
     public PerformanceTestResult parse(PerformanceTestResult performanceTestResult) {
+        if (!MachineInfoUtils.isOnWindowsLaptop()) {
+            classLogger.error("Windows battery test must be run on Windows Laptop!");
+            return null;
+        }
+
         try {
             // Wait 20 seconds for the results to be completely written to the hard disk.
             Thread.sleep(20 * 1000);

--- a/common/src/main/java/com/microsoft/hydralab/performance/parsers/WindowsBatteryResultParser.java
+++ b/common/src/main/java/com/microsoft/hydralab/performance/parsers/WindowsBatteryResultParser.java
@@ -43,6 +43,12 @@ public class WindowsBatteryResultParser implements PerformanceResultParser {
 
     @Override
     public PerformanceTestResult parse(PerformanceTestResult performanceTestResult) {
+        try {
+            Thread.sleep(20 * 1000);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+
         boolean baseLineFound = false;
         String baseLine = "";
 

--- a/common/src/main/java/com/microsoft/hydralab/performance/parsers/WindowsBatteryResultParser.java
+++ b/common/src/main/java/com/microsoft/hydralab/performance/parsers/WindowsBatteryResultParser.java
@@ -55,6 +55,10 @@ public class WindowsBatteryResultParser implements PerformanceResultParser {
 
         for (PerformanceInspectionResult inspectionResult : performanceTestResult.performanceInspectionResults)
         {
+            if (inspectionResult == null) {
+                continue;
+            }
+
             try (ReversedLinesFileReader reversedReader = new ReversedLinesFileReader(inspectionResult.rawResultFile,
                     StandardCharsets.UTF_8);) {
                 WindowsBatteryParsedData windowsBatteryParsedData = new WindowsBatteryParsedData();

--- a/common/src/main/java/com/microsoft/hydralab/performance/parsers/WindowsMemoryResultParser.java
+++ b/common/src/main/java/com/microsoft/hydralab/performance/parsers/WindowsMemoryResultParser.java
@@ -31,6 +31,10 @@ public class WindowsMemoryResultParser implements PerformanceResultParser {
     public PerformanceTestResult parse(PerformanceTestResult performanceTestResult) {
         for (PerformanceInspectionResult inspectionResult : performanceTestResult.performanceInspectionResults)
         {
+            if (inspectionResult == null) {
+                continue;
+            }
+
             try (BufferedReader reader = new BufferedReader(new FileReader(inspectionResult.rawResultFile,
                     StandardCharsets.UTF_16))) {
                 WindowsMemoryParsedData parsedData = new WindowsMemoryParsedData();

--- a/common/src/main/java/com/microsoft/hydralab/performance/parsers/WindowsMemoryResultParser.java
+++ b/common/src/main/java/com/microsoft/hydralab/performance/parsers/WindowsMemoryResultParser.java
@@ -29,12 +29,6 @@ public class WindowsMemoryResultParser implements PerformanceResultParser {
 
     @Override
     public PerformanceTestResult parse(PerformanceTestResult performanceTestResult) {
-        try {
-            Thread.sleep(5 * 1000);
-        } catch (InterruptedException e) {
-            throw new RuntimeException(e);
-        }
-
         for (PerformanceInspectionResult inspectionResult : performanceTestResult.performanceInspectionResults)
         {
             try (BufferedReader reader = new BufferedReader(new FileReader(inspectionResult.rawResultFile,

--- a/common/src/main/java/com/microsoft/hydralab/performance/parsers/WindowsMemoryResultParser.java
+++ b/common/src/main/java/com/microsoft/hydralab/performance/parsers/WindowsMemoryResultParser.java
@@ -29,6 +29,12 @@ public class WindowsMemoryResultParser implements PerformanceResultParser {
 
     @Override
     public PerformanceTestResult parse(PerformanceTestResult performanceTestResult) {
+        try {
+            Thread.sleep(5 * 1000);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+
         for (PerformanceInspectionResult inspectionResult : performanceTestResult.performanceInspectionResults)
         {
             try (BufferedReader reader = new BufferedReader(new FileReader(inspectionResult.rawResultFile,

--- a/common/src/main/resources/DetectWindowsLaptop.ps1
+++ b/common/src/main/resources/DetectWindowsLaptop.ps1
@@ -1,0 +1,25 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+$isWindowsLaptop = $false
+
+# See more info regarding ChassisTypes: https://powershell.one/wmi/root/cimv2/win32_systemenclosure#chassistypes
+# 9-Laptop, 10-Notebook, 14-Sub Notebook
+$isWindowsLaptop = [bool](Get-WmiObject -Class Win32_SystemEnclosure | Where-Object ChassisTypes -in '9', '10', '14')
+
+# By checking the battery status, it can be determined if the device is a laptop.
+if ((-not $isWindowsLaptop) -and (Get-WmiObject -Class win32_battery))
+{
+    $isWindowsLaptop = $true
+}
+
+if ($isWindowsLaptop)
+{
+    Write-Host "Yes"
+}
+else
+{
+    Write-Host "No"
+}
+
+exit 0

--- a/common/src/main/resources/WindowsBatteryInspector.ps1
+++ b/common/src/main/resources/WindowsBatteryInspector.ps1
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 param (
-	[string]$output = ""
+    [string]$output = ""
 )
 
 if ($output -eq "") {

--- a/common/src/main/resources/WindowsBatteryInspector.ps1
+++ b/common/src/main/resources/WindowsBatteryInspector.ps1
@@ -1,0 +1,16 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+param (
+	[string]$output = ""
+)
+
+if ($output -eq "") {
+    Write-Host "-output is required."
+    Read-Host -Prompt "output is empty."
+    exit 1
+}
+
+Start-Process -FilePath Powershell.exe -Verb RunAs -WindowStyle Hidden -ArgumentList "-command ""powercfg /srumutil /OUTPUT $output /CSV"""
+
+exit 0

--- a/common/src/main/resources/WindowsMemoryInspector.ps1
+++ b/common/src/main/resources/WindowsMemoryInspector.ps1
@@ -3,7 +3,7 @@
 
 param (
     [string]$keyword = "Phone",
-	[string]$output = ""
+    [string]$output = ""
 )
 
 if ($output -eq "") {


### PR DESCRIPTION
## Description
<!-- Please write a brief information about PR, what it contains, its purpose -->

1. Fix the compatibility issue that WindowsBatteryInpector.ps1 cannot be executed with Runtime class.
2. Add null check for each inspectionResult item in the for loop of parsers.


## Screenshots
<!-- Please add screenshots -->
No.

## Testing
<!-- How to test PR -->
Windows Perf is still in progress, no need to test for now.
