### PR TITLE
BugFix: the args of adbMonkey should be ahead of click times

### DIFF
--- a/agent/src/main/java/com/microsoft/hydralab/agent/runner/monkey/AdbMonkeyRunner.java
+++ b/agent/src/main/java/com/microsoft/hydralab/agent/runner/monkey/AdbMonkeyRunner.java
@@ -161,7 +161,7 @@ public class AdbMonkeyRunner extends TestRunner {
         if (StringUtils.isBlank(argString.toString())) {
             commFormat = "monkey -p %s %d";
         } else {
-            commFormat = "monkey -p %s %d" + argString;
+            commFormat = "monkey -p %s " + argString + " %d";
         }
         try {
             String command = String.format(commFormat, pkgName, maxStepCount);


### PR DESCRIPTION
## Description
<!-- Please write a brief information about PR, what it contains, its purpose -->
### Update command format to enable customization configs.
## Screenshots
<!-- Please add screenshots -->
### Before
![image](https://user-images.githubusercontent.com/26757995/223966473-ed19ca33-d8e4-4d74-af46-1593f11ae537.png)

### After

![image](https://user-images.githubusercontent.com/26757995/223966702-febd0afa-4e8a-4cf8-9f87-3e19f2f510b8.png)

## Testing
<!-- How to test PR -->
Trigger a ADB Monkey with test config {"config":"--throttle 100 -v -v"}
![image](https://user-images.githubusercontent.com/26757995/223967117-f496c5d4-43d8-4f78-a6a9-4649c7bd8297.png)
