### PR TITLE
Fix the linux path check bug, and add UT

### DIFF
--- a/common/src/main/java/com/microsoft/hydralab/common/util/ADBOperateUtil.java
+++ b/common/src/main/java/com/microsoft/hydralab/common/util/ADBOperateUtil.java
@@ -45,11 +45,11 @@ public class ADBOperateUtil {
 
         boolean onWindows = MachineInfoUtils.isOnWindows();
         if (onWindows) {
-            if (LogUtils.isLegalStr(mAndroidHome, Const.RegexString.WINDOWS_PATH, false)) {
+            if (LogUtils.isLegalStr(mAndroidHome, Const.RegexString.WINDOWS_ABSOLUTE_PATH, false)) {
                 mAdbPath = new File(mAndroidHome, "platform-tools" + File.separator + "adb.exe");
             }
         } else {
-            if (LogUtils.isLegalStr(mAndroidHome, Const.RegexString.LINUX_PATH, false)) {
+            if (LogUtils.isLegalStr(mAndroidHome, Const.RegexString.LINUX_ABSOLUTE_PATH, false)) {
                 mAdbPath = new File(mAndroidHome, "platform-tools" + File.separator + "adb");
             }
         }

--- a/common/src/main/java/com/microsoft/hydralab/common/util/Const.java
+++ b/common/src/main/java/com/microsoft/hydralab/common/util/Const.java
@@ -105,7 +105,7 @@ public interface Const {
         String MAIL_ADDRESS = "\\w+([-+.]\\w+)*@\\w+([-.]\\w+)*\\.\\w+([-.]\\w+)*";
 
         //File path
-        String LINUX_ABSOLUTE_PATH = "^(\\/[\\w-.]+)+\\/?$";
+        String LINUX_ABSOLUTE_PATH = "^(\\/[\\w\\s_<>?-.]+)+\\/?$";
         String WINDOWS_ABSOLUTE_PATH = "^([a-zA-Z]:)(\\\\[^/\\\\:*?\"<>|]+\\\\?)*$";
 
         //Package name

--- a/common/src/main/java/com/microsoft/hydralab/common/util/Const.java
+++ b/common/src/main/java/com/microsoft/hydralab/common/util/Const.java
@@ -105,7 +105,7 @@ public interface Const {
         String MAIL_ADDRESS = "\\w+([-+.]\\w+)*@\\w+([-.]\\w+)*\\.\\w+([-.]\\w+)*";
 
         //File path
-        String LINUX_ABSOLUTE_PATH = "^(\\/[\\w\\s_<>?-.]+)+\\/?$";
+        String LINUX_ABSOLUTE_PATH = "^(\\/[\\w\\s<>?.\\-]+)+\\/?$";
         String WINDOWS_ABSOLUTE_PATH = "^([a-zA-Z]:)(\\\\[^/\\\\:*?\"<>|]+\\\\?)*$";
 
         //Package name

--- a/common/src/main/java/com/microsoft/hydralab/common/util/Const.java
+++ b/common/src/main/java/com/microsoft/hydralab/common/util/Const.java
@@ -106,7 +106,7 @@ public interface Const {
 
         //File path
         // There are almost no restrictions - apart from '/' and '\0', you're allowed to use anything. Hence the below is only an adoption for the most cases
-        String LINUX_ABSOLUTE_PATH = "^(\\/[\\S ]+)+\\/?$";
+        String LINUX_ABSOLUTE_PATH = "^(\\/[^\\t\\f\\n\\r\\v]+)+\\/?$";
         String WINDOWS_ABSOLUTE_PATH = "^([a-zA-Z]:)(\\\\[^/\\\\:*?\"<>|]+\\\\?)*$";
 
         //Package name

--- a/common/src/main/java/com/microsoft/hydralab/common/util/Const.java
+++ b/common/src/main/java/com/microsoft/hydralab/common/util/Const.java
@@ -105,8 +105,8 @@ public interface Const {
         String MAIL_ADDRESS = "\\w+([-+.]\\w+)*@\\w+([-.]\\w+)*\\.\\w+([-.]\\w+)*";
 
         //File path
-        String LINUX_PATH = "^(\\/[\\w-]+)+\\/?$";
-        String WINDOWS_PATH = "^([a-zA-Z]:)(\\\\[^/\\\\:*?\"<>|]+\\\\?)*$";
+        String LINUX_ABSOLUTE_PATH = "^(\\/[\\w-.]+)+\\/?$";
+        String WINDOWS_ABSOLUTE_PATH = "^([a-zA-Z]:)(\\\\[^/\\\\:*?\"<>|]+\\\\?)*$";
 
         //Package name
         String PACKAGE_NAME = "\\w+([-.]\\w+)*\\.\\w+([-.]\\w+)*";

--- a/common/src/main/java/com/microsoft/hydralab/common/util/Const.java
+++ b/common/src/main/java/com/microsoft/hydralab/common/util/Const.java
@@ -105,7 +105,8 @@ public interface Const {
         String MAIL_ADDRESS = "\\w+([-+.]\\w+)*@\\w+([-.]\\w+)*\\.\\w+([-.]\\w+)*";
 
         //File path
-        String LINUX_ABSOLUTE_PATH = "^(\\/[\\w\\s<>?.\\-]+)+\\/?$";
+        // There are almost no restrictions - apart from '/' and '\0', you're allowed to use anything. Hence the below is only an adoption for the most cases
+        String LINUX_ABSOLUTE_PATH = "^(\\/[\\S ]+)+\\/?$";
         String WINDOWS_ABSOLUTE_PATH = "^([a-zA-Z]:)(\\\\[^/\\\\:*?\"<>|]+\\\\?)*$";
 
         //Package name

--- a/common/src/main/java/com/microsoft/hydralab/common/util/LogUtils.java
+++ b/common/src/main/java/com/microsoft/hydralab/common/util/LogUtils.java
@@ -98,6 +98,9 @@ public class LogUtils {
         }
     }
 
+    /**
+     * TODO: this should be put to a Util class for String
+     */
     public static Boolean isLegalStr(String message, String regex, Boolean nullable) {
         if (StringUtils.isEmpty(message)) {
             return nullable;

--- a/common/src/main/java/com/microsoft/hydralab/common/util/LogUtils.java
+++ b/common/src/main/java/com/microsoft/hydralab/common/util/LogUtils.java
@@ -99,7 +99,7 @@ public class LogUtils {
     }
 
     /**
-     * TODO: this should be put to a Util class for String
+     * TODO: this should be moved to a Util class for String
      */
     public static Boolean isLegalStr(String message, String regex, Boolean nullable) {
         if (StringUtils.isEmpty(message)) {

--- a/common/src/test/java/com/microsoft/hydralab/common/util/StringUtilsTest.java
+++ b/common/src/test/java/com/microsoft/hydralab/common/util/StringUtilsTest.java
@@ -17,5 +17,7 @@ public class StringUtilsTest {
         Assertions.assertTrue(LogUtils.isLegalStr("C:\\Program Files (x86)\\Common Files", Const.RegexString.WINDOWS_ABSOLUTE_PATH,false));
         Assertions.assertTrue(LogUtils.isLegalStr("C:\\Program Files (x86)\\Common Files\\Microsoft Shared\\Phone Tools\\15.0", Const.RegexString.WINDOWS_ABSOLUTE_PATH,false));
         Assertions.assertFalse(LogUtils.isLegalStr("~", Const.RegexString.WINDOWS_ABSOLUTE_PATH,false));
+        Assertions.assertFalse(LogUtils.isLegalStr("Common Files\\Microsoft Shared\\Phone Tools", Const.RegexString.WINDOWS_ABSOLUTE_PATH,false));
+        Assertions.assertFalse(LogUtils.isLegalStr("\\Program Files (x86)", Const.RegexString.WINDOWS_ABSOLUTE_PATH,false));
     }
 }

--- a/common/src/test/java/com/microsoft/hydralab/common/util/StringUtilsTest.java
+++ b/common/src/test/java/com/microsoft/hydralab/common/util/StringUtilsTest.java
@@ -9,6 +9,7 @@ public class StringUtilsTest {
         Assertions.assertTrue(LogUtils.isLegalStr("/opt/homebrew/android_sdk/34.0.0", Const.RegexString.LINUX_ABSOLUTE_PATH,false));
         Assertions.assertFalse(LogUtils.isLegalStr("opt/homebrew/android_sdk/", Const.RegexString.LINUX_ABSOLUTE_PATH,false));
         Assertions.assertTrue(LogUtils.isLegalStr("/opt/homebrew", Const.RegexString.LINUX_ABSOLUTE_PATH,false));
+        Assertions.assertTrue(LogUtils.isLegalStr("/path/to/ab-c/abc 2/12.3", Const.RegexString.LINUX_ABSOLUTE_PATH,false));
         Assertions.assertFalse(LogUtils.isLegalStr("0", Const.RegexString.LINUX_ABSOLUTE_PATH,false));
         Assertions.assertFalse(LogUtils.isLegalStr("abc", Const.RegexString.LINUX_ABSOLUTE_PATH,false));
         Assertions.assertFalse(LogUtils.isLegalStr("~", Const.RegexString.LINUX_ABSOLUTE_PATH,false));

--- a/common/src/test/java/com/microsoft/hydralab/common/util/StringUtilsTest.java
+++ b/common/src/test/java/com/microsoft/hydralab/common/util/StringUtilsTest.java
@@ -1,0 +1,21 @@
+package com.microsoft.hydralab.common.util;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class StringUtilsTest {
+    @Test
+    public void testPathVerification(){
+        Assertions.assertTrue(LogUtils.isLegalStr("/opt/homebrew/android_sdk/34.0.0", Const.RegexString.LINUX_ABSOLUTE_PATH,false));
+        Assertions.assertFalse(LogUtils.isLegalStr("opt/homebrew/android_sdk/", Const.RegexString.LINUX_ABSOLUTE_PATH,false));
+        Assertions.assertTrue(LogUtils.isLegalStr("/opt/homebrew", Const.RegexString.LINUX_ABSOLUTE_PATH,false));
+        Assertions.assertFalse(LogUtils.isLegalStr("0", Const.RegexString.LINUX_ABSOLUTE_PATH,false));
+        Assertions.assertFalse(LogUtils.isLegalStr("abc", Const.RegexString.LINUX_ABSOLUTE_PATH,false));
+        Assertions.assertFalse(LogUtils.isLegalStr("~", Const.RegexString.LINUX_ABSOLUTE_PATH,false));
+
+        Assertions.assertTrue(LogUtils.isLegalStr("C:\\123.5\\AndroidSDK\\a", Const.RegexString.WINDOWS_ABSOLUTE_PATH,false));
+        Assertions.assertTrue(LogUtils.isLegalStr("C:\\Program Files (x86)\\Common Files", Const.RegexString.WINDOWS_ABSOLUTE_PATH,false));
+        Assertions.assertTrue(LogUtils.isLegalStr("C:\\Program Files (x86)\\Common Files\\Microsoft Shared\\Phone Tools\\15.0", Const.RegexString.WINDOWS_ABSOLUTE_PATH,false));
+        Assertions.assertFalse(LogUtils.isLegalStr("~", Const.RegexString.WINDOWS_ABSOLUTE_PATH,false));
+    }
+}

--- a/common/src/test/java/com/microsoft/hydralab/common/util/StringUtilsTest.java
+++ b/common/src/test/java/com/microsoft/hydralab/common/util/StringUtilsTest.java
@@ -18,6 +18,7 @@ public class StringUtilsTest {
 
         Assertions.assertTrue(LogUtils.isLegalStr("C:\\123.5\\AndroidSDK\\a", Const.RegexString.WINDOWS_ABSOLUTE_PATH,false));
         Assertions.assertTrue(LogUtils.isLegalStr("C:\\Program Files (x86)\\Common Files", Const.RegexString.WINDOWS_ABSOLUTE_PATH,false));
+        Assertions.assertTrue(LogUtils.isLegalStr("C:\\Program Files (x86)\\安卓SDK", Const.RegexString.WINDOWS_ABSOLUTE_PATH,false));
         Assertions.assertTrue(LogUtils.isLegalStr("C:\\Program Files (x86)\\Common Files\\Microsoft Shared\\Phone Tools\\15.0", Const.RegexString.WINDOWS_ABSOLUTE_PATH,false));
         Assertions.assertFalse(LogUtils.isLegalStr("~", Const.RegexString.WINDOWS_ABSOLUTE_PATH,false));
         Assertions.assertFalse(LogUtils.isLegalStr("Common Files\\Microsoft Shared\\Phone Tools", Const.RegexString.WINDOWS_ABSOLUTE_PATH,false));

--- a/common/src/test/java/com/microsoft/hydralab/common/util/StringUtilsTest.java
+++ b/common/src/test/java/com/microsoft/hydralab/common/util/StringUtilsTest.java
@@ -10,6 +10,7 @@ public class StringUtilsTest {
         Assertions.assertFalse(LogUtils.isLegalStr("opt/homebrew/android_sdk/", Const.RegexString.LINUX_ABSOLUTE_PATH,false));
         Assertions.assertTrue(LogUtils.isLegalStr("/opt/homebrew", Const.RegexString.LINUX_ABSOLUTE_PATH,false));
         Assertions.assertTrue(LogUtils.isLegalStr("/path/to/ab-c/abc 2/12.3", Const.RegexString.LINUX_ABSOLUTE_PATH,false));
+        Assertions.assertTrue(LogUtils.isLegalStr("/path/.git/.jdk/to/ab-c/abc 2/12.3?", Const.RegexString.LINUX_ABSOLUTE_PATH,false));
         Assertions.assertFalse(LogUtils.isLegalStr("0", Const.RegexString.LINUX_ABSOLUTE_PATH,false));
         Assertions.assertFalse(LogUtils.isLegalStr("abc", Const.RegexString.LINUX_ABSOLUTE_PATH,false));
         Assertions.assertFalse(LogUtils.isLegalStr("~", Const.RegexString.LINUX_ABSOLUTE_PATH,false));

--- a/common/src/test/java/com/microsoft/hydralab/common/util/StringUtilsTest.java
+++ b/common/src/test/java/com/microsoft/hydralab/common/util/StringUtilsTest.java
@@ -9,7 +9,7 @@ public class StringUtilsTest {
         Assertions.assertTrue(LogUtils.isLegalStr("/opt/homebrew/android_sdk/34.0.0", Const.RegexString.LINUX_ABSOLUTE_PATH,false));
         Assertions.assertFalse(LogUtils.isLegalStr("opt/homebrew/android_sdk/", Const.RegexString.LINUX_ABSOLUTE_PATH,false));
         Assertions.assertTrue(LogUtils.isLegalStr("/opt/homebrew", Const.RegexString.LINUX_ABSOLUTE_PATH,false));
-        Assertions.assertTrue(LogUtils.isLegalStr("/path/to/ab-c/abc 2/12.3", Const.RegexString.LINUX_ABSOLUTE_PATH,false));
+        Assertions.assertTrue(LogUtils.isLegalStr("/Path/To/ab-c/abc 2/12.3", Const.RegexString.LINUX_ABSOLUTE_PATH,false));
         Assertions.assertTrue(LogUtils.isLegalStr("/path/.git/.jdk/to/ab-c/abc 2/12.3?", Const.RegexString.LINUX_ABSOLUTE_PATH,false));
         Assertions.assertFalse(LogUtils.isLegalStr("0", Const.RegexString.LINUX_ABSOLUTE_PATH,false));
         Assertions.assertFalse(LogUtils.isLegalStr("abc", Const.RegexString.LINUX_ABSOLUTE_PATH,false));

--- a/common/src/test/java/com/microsoft/hydralab/common/util/StringUtilsTest.java
+++ b/common/src/test/java/com/microsoft/hydralab/common/util/StringUtilsTest.java
@@ -10,6 +10,7 @@ public class StringUtilsTest {
         Assertions.assertFalse(LogUtils.isLegalStr("opt/homebrew/android_sdk/", Const.RegexString.LINUX_ABSOLUTE_PATH,false));
         Assertions.assertTrue(LogUtils.isLegalStr("/opt/homebrew", Const.RegexString.LINUX_ABSOLUTE_PATH,false));
         Assertions.assertTrue(LogUtils.isLegalStr("/Path/To/ab-c/abc 2/12.3", Const.RegexString.LINUX_ABSOLUTE_PATH,false));
+        Assertions.assertTrue(LogUtils.isLegalStr("/Path/安卓系统/ab-c/abc 2/12.3", Const.RegexString.LINUX_ABSOLUTE_PATH,false));
         Assertions.assertTrue(LogUtils.isLegalStr("/path/.git/.jdk/to/ab-c/abc 2/12.3?", Const.RegexString.LINUX_ABSOLUTE_PATH,false));
         Assertions.assertFalse(LogUtils.isLegalStr("0", Const.RegexString.LINUX_ABSOLUTE_PATH,false));
         Assertions.assertFalse(LogUtils.isLegalStr("abc", Const.RegexString.LINUX_ABSOLUTE_PATH,false));


### PR DESCRIPTION
## Description
Fix the  regex bug. For Linux file names, there are almost no restrictions - apart from '/' and '\0', you're allowed to use anything. So adding more allowed options will help correctly identify the path.

## Screenshots
<!-- Please add screenshots -->

## Testing
Add UT
