### PR TITLE
Update installer.sh to support the ANDROID_HOME env automation

### DIFF
--- a/agent/agent_installer/MacOS/iOS/installer.sh
+++ b/agent/agent_installer/MacOS/iOS/installer.sh
@@ -89,13 +89,21 @@ chmod +x "$scriptPath/restartAgent.sh"
 chmod +x "$scriptPath/HydraAgent.sh"
 
 ### copy files 
-echo "Copying Files......"
-echo "Work Folder: $serverPath"
+echo "Copying Files to Work Folder: $serverPath"
 mkdir -p "$serverPath"
 sudo mkdir -p "$supervisorPath"
 sudo cp "$iniFile" "$supervisorPath/HydraLabAgent.ini"
 jarPath=$(find "$scriptPath" -type f -name "*agent*")
 yamlPath=$(find "$scriptPath" -type f -name "*application.y*")
+
+if [ -z "$yamlPath" ]
+then
+    echo "application YAML file found, please refer to the guide in
+    https://github.com/microsoft/HydraLab/wiki/Test-agent-setup#download-the-agent-configuration
+    and download the application.yml from the Hydra Lab Portal, and put it in this folder."
+    exit 1
+fi
+
 cp "$scriptPath/HydraAgent.sh" "$serverPath/HydraAgent.sh"
 cp "$scriptPath/restartAgent.sh" "$serverPath/restartAgent.sh"
 cp "$jarPath" "$serverPath/agent.jar"

--- a/agent/agent_installer/MacOS/iOS/installer.sh
+++ b/agent/agent_installer/MacOS/iOS/installer.sh
@@ -9,7 +9,7 @@ scriptPath=$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )
 
 userHome=$(eval echo ~)
 
-### install enviroment
+### install environment
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 echo 'eval "$(/opt/homebrew/bin/brew shellenv)"' >> "$userHome/.zprofile"
 eval "$(/opt/homebrew/bin/brew shellenv)"
@@ -19,19 +19,20 @@ brew install awk
 brew install android-platform-tools
 
 # trace adb path and set ANDROID_HOME as env var
-adb_path=`which adb`
+adb_path=$(which adb)
 # example value of this adb_path here: 
 # lrwxr-xr-x  1 bsp  admin  71 Mar 10 18:47 /opt/homebrew/bin/adb -> /opt/homebrew/Caskroom/android-platform-tools/34.0.0/platform-tools/adb
-adb_path=`ls -l $adb_path`
-echo $adb_path > temp.txt
-adb_path=`awk -F '-> ' '{print $2}' temp.txt`
-echo $adb_path > temp.txt
-export ANDROID_HOME=`awk -F '/platform-tools/' '{print $1}' temp.txt`
-echo $ANDROID_HOME
-echo "\nexport ANDROID_HOME=$ANDROID_HOME" >> export_android_home.sh
+adb_path=$(ls -l "$adb_path")
+echo "$adb_path" > temp.txt
+adb_path=$(awk -F '-> ' '{print $2}' temp.txt)
+echo "$adb_path" > temp.txt
+export ANDROID_HOME=$(awk -F '/platform-tools/' '{print $1}' temp.txt)
+echo "$ANDROID_HOME"
+echo "\nexport ANDROID_HOME=$ANDROID_HOME" > export_android_home.sh
 cat export_android_home.sh >> ~/.zshrc
+rm temp.txt
 
-brew install maven
+# brew install maven
 brew install libimobiledevice
 brew install --build-from-source python@3.9
 brew install ffmpeg

--- a/agent/agent_installer/MacOS/iOS/installer.sh
+++ b/agent/agent_installer/MacOS/iOS/installer.sh
@@ -20,6 +20,9 @@ brew install android-platform-tools
 
 # trace adb path and set ANDROID_HOME as env var
 adb_path=`which adb`
+# example value of this adb_path here: 
+# lrwxr-xr-x  1 bsp  admin  71 Mar 10 18:47 /opt/homebrew/bin/adb -> /opt/homebrew/Caskroom/android-platform-tools/34.0.0/platform-tools/adb
+
 adb_path=`ls -l $adb_path`
 echo $adb_path > temp.txt
 adb_path=`awk -F '-> ' '{print $2}' temp.txt`

--- a/agent/agent_installer/MacOS/iOS/installer.sh
+++ b/agent/agent_installer/MacOS/iOS/installer.sh
@@ -22,7 +22,6 @@ brew install android-platform-tools
 adb_path=`which adb`
 # example value of this adb_path here: 
 # lrwxr-xr-x  1 bsp  admin  71 Mar 10 18:47 /opt/homebrew/bin/adb -> /opt/homebrew/Caskroom/android-platform-tools/34.0.0/platform-tools/adb
-
 adb_path=`ls -l $adb_path`
 echo $adb_path > temp.txt
 adb_path=`awk -F '-> ' '{print $2}' temp.txt`

--- a/agent/agent_installer/MacOS/iOS/installer.sh
+++ b/agent/agent_installer/MacOS/iOS/installer.sh
@@ -13,7 +13,7 @@ yamlPath=$(find "$scriptPath" -type f -name "*application.*")
 
 if [ -z "$yamlPath" ]
 then
-    echo "application YAML file found, please refer to the guide in
+    echo "application YAML file is not found, please refer to the guide in
     https://github.com/microsoft/HydraLab/wiki/Test-agent-setup#download-the-agent-configuration
     and download the application.yml from the Hydra Lab Portal, and put it in this folder."
     exit 1

--- a/agent/agent_installer/MacOS/iOS/installer.sh
+++ b/agent/agent_installer/MacOS/iOS/installer.sh
@@ -106,7 +106,6 @@ mkdir -p "$serverPath"
 sudo mkdir -p "$supervisorPath"
 sudo cp "$iniFile" "$supervisorPath/HydraLabAgent.ini"
 jarPath=$(find "$scriptPath" -type f -name "*agent*")
-
 cp "$scriptPath/HydraAgent.sh" "$serverPath/HydraAgent.sh"
 cp "$scriptPath/restartAgent.sh" "$serverPath/restartAgent.sh"
 cp "$jarPath" "$serverPath/agent.jar"

--- a/agent/agent_installer/MacOS/iOS/installer.sh
+++ b/agent/agent_installer/MacOS/iOS/installer.sh
@@ -15,6 +15,20 @@ echo 'eval "$(/opt/homebrew/bin/brew shellenv)"' >> "$userHome/.zprofile"
 eval "$(/opt/homebrew/bin/brew shellenv)"
 brew install carthage
 brew install node
+brew install awk
+brew install android-platform-tools
+
+# trace adb path and set ANDROID_HOME as env var
+adb_path=`which adb`
+adb_path=`ls -l $adb_path`
+echo $adb_path > temp.txt
+adb_path=`awk -F '-> ' '{print $2}' temp.txt`
+echo $adb_path > temp.txt
+export ANDROID_HOME=`awk -F '/platform-tools/' '{print $1}' temp.txt`
+echo $ANDROID_HOME
+echo "\nexport ANDROID_HOME=$ANDROID_HOME" >> export_android_home.sh
+cat export_android_home.sh >> ~/.zshrc
+
 brew install maven
 brew install libimobiledevice
 brew install --build-from-source python@3.9

--- a/agent/agent_installer/MacOS/iOS/installer.sh
+++ b/agent/agent_installer/MacOS/iOS/installer.sh
@@ -15,6 +15,7 @@ echo 'eval "$(/opt/homebrew/bin/brew shellenv)"' >> "$userHome/.zprofile"
 eval "$(/opt/homebrew/bin/brew shellenv)"
 brew install carthage
 brew install node
+
 brew install awk
 brew install android-platform-tools
 

--- a/agent/agent_installer/MacOS/iOS/installer.sh
+++ b/agent/agent_installer/MacOS/iOS/installer.sh
@@ -79,7 +79,7 @@ end tell'
 processid=\$(ps aux | grep agent | grep -v \"grep\" | awk '{ print \$2}')
 kill \$processid
 export PATH=\"/opt/homebrew/opt/openjdk@11/bin:/opt/homebrew/bin:\$PATH\"
-java -Xms1024m -Xmx2048m -jar ~/Library/Server/HydraLab/agent.jar --spring.config.location=config/
+java -Xms1024m -Xmx2048m -jar ~/Library/Server/HydraLab/agent.jar
 " >> "$agentTaskFile"
 
 chmod +x "$scriptPath/restartAgent.sh"

--- a/agent/agent_installer/MacOS/iOS/installer.sh
+++ b/agent/agent_installer/MacOS/iOS/installer.sh
@@ -34,14 +34,14 @@ cat export_android_home.sh >> ~/.zshrc
 rm temp.txt
 
 # brew install maven
-brew install libimobiledevice
+brew list libimobiledevice || brew install libimobiledevice
 brew install --build-from-source python@3.9
-brew install ffmpeg
+brew list ffmpeg || brew install ffmpeg
 
-brew install supervisor
-brew install services
+brew list supervisor || brew install supervisor
+brew list services || brew install services
 
-brew install openjdk@11
+brew list openjdk@11 || brew install openjdk@11
 
 npm install -g ios-deploy
 npm install -g appium

--- a/agent/agent_installer/MacOS/iOS/installer.sh
+++ b/agent/agent_installer/MacOS/iOS/installer.sh
@@ -7,6 +7,18 @@ fi
 
 scriptPath=$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )
 
+echo "This script will install the agent for MacOS, and it will take 10-30 minutes to finish."
+echo "Checking if the application configuration is provided......"
+yamlPath=$(find "$scriptPath" -type f -name "*application.*")
+
+if [ -z "$yamlPath" ]
+then
+    echo "application YAML file found, please refer to the guide in
+    https://github.com/microsoft/HydraLab/wiki/Test-agent-setup#download-the-agent-configuration
+    and download the application.yml from the Hydra Lab Portal, and put it in this folder."
+    exit 1
+fi
+
 userHome=$(eval echo ~)
 
 ### install environment
@@ -94,15 +106,6 @@ mkdir -p "$serverPath"
 sudo mkdir -p "$supervisorPath"
 sudo cp "$iniFile" "$supervisorPath/HydraLabAgent.ini"
 jarPath=$(find "$scriptPath" -type f -name "*agent*")
-yamlPath=$(find "$scriptPath" -type f -name "*application.y*")
-
-if [ -z "$yamlPath" ]
-then
-    echo "application YAML file found, please refer to the guide in
-    https://github.com/microsoft/HydraLab/wiki/Test-agent-setup#download-the-agent-configuration
-    and download the application.yml from the Hydra Lab Portal, and put it in this folder."
-    exit 1
-fi
 
 cp "$scriptPath/HydraAgent.sh" "$serverPath/HydraAgent.sh"
 cp "$scriptPath/restartAgent.sh" "$serverPath/restartAgent.sh"

--- a/agent/agent_installer/MacOS/iOS/installer.sh
+++ b/agent/agent_installer/MacOS/iOS/installer.sh
@@ -34,14 +34,14 @@ cat export_android_home.sh >> ~/.zshrc
 rm temp.txt
 
 # brew install maven
-brew list libimobiledevice || brew install libimobiledevice
+brew install libimobiledevice
 brew install --build-from-source python@3.9
-brew list ffmpeg || brew install ffmpeg
+brew install ffmpeg
 
-brew list supervisor || brew install supervisor
-brew list services || brew install services
+brew install supervisor
+brew install services
 
-brew list openjdk@11 || brew install openjdk@11
+brew install openjdk@11
 
 npm install -g ios-deploy
 npm install -g appium

--- a/agent/agent_installer/MacOS/iOS/installer.sh
+++ b/agent/agent_installer/MacOS/iOS/installer.sh
@@ -81,6 +81,7 @@ end tell'
 processid=\$(ps aux | grep agent | grep -v \"grep\" | awk '{ print \$2}')
 kill \$processid
 export PATH=\"/opt/homebrew/opt/openjdk@11/bin:/opt/homebrew/bin:\$PATH\"
+export ANDROID_HOME=\"$ANDROID_HOME\"
 java -Xms1024m -Xmx2048m -jar ~/Library/Server/HydraLab/agent.jar
 " >> "$agentTaskFile"
 

--- a/agent/agent_installer/MacOS/iOS/installer.sh
+++ b/agent/agent_installer/MacOS/iOS/installer.sh
@@ -95,9 +95,11 @@ mkdir -p "$serverPath"
 sudo mkdir -p "$supervisorPath"
 sudo cp "$iniFile" "$supervisorPath/HydraLabAgent.ini"
 jarPath=$(find "$scriptPath" -type f -name "*agent*")
+yamlPath=$(find "$scriptPath" -type f -name "*application.y*")
 cp "$scriptPath/HydraAgent.sh" "$serverPath/HydraAgent.sh"
 cp "$scriptPath/restartAgent.sh" "$serverPath/restartAgent.sh"
 cp "$jarPath" "$serverPath/agent.jar"
+cp "$yamlPath" "$serverPath/application.yml"
 echo "Files copy finished."
 
 ### start agent


### PR DESCRIPTION
## Description
Update make it easier for user to install agent on MacOS.

## Screenshots
<!-- Please add screenshots -->

## Testing

Tested on my MacOS. This is hard to test. So we might need to figure out a way for testing and ensuring the quality of the script, this `installer.sh` is a part of the user experience as well and we need to make sure its accountability.