### PR TITLE
[Perf] Add a new chart for Windows memory performance test in Test Report

### DIFF
--- a/react/src/component/PerfTestDashboard.jsx
+++ b/react/src/component/PerfTestDashboard.jsx
@@ -53,8 +53,8 @@ const windowsMemoryOptions = [
 export default class PerfTestDashboard extends React.Component {
     state = {
         perfTestResult: this.props.perfTestResult,
-        memoryInfo: undefined,
-        batteryInfo: undefined,
+        androidMemoryInfo: undefined,
+        androidBatteryInfo: undefined,
         windowsMemoryInfo: undefined,
         selectedAndroidBatteryOptions: androidBatteryOptions.slice(0, 4),
         selectedAndroidMemoryOptions: androidMemoryOptions.slice(0, 10),
@@ -62,9 +62,9 @@ export default class PerfTestDashboard extends React.Component {
     };
 
     render() {
-        const memoryInfo = this.state.memoryInfo;
+        const androidMemoryInfo = this.state.androidMemoryInfo;
         const memoryMetrics = [];
-        const batteryInfo = this.state.batteryInfo;
+        const androidBatteryInfo = this.state.androidBatteryInfo;
         const batteryMetrics = [];
         const windowsMemoryInfo = this.state.windowsMemoryInfo;
         const windowsMemoryMetrics = [];
@@ -72,9 +72,9 @@ export default class PerfTestDashboard extends React.Component {
         /**
          * Battery Info
          */
-        if (batteryInfo && batteryInfo.performanceInspectionResults && batteryInfo.performanceInspectionResults.length > 0) {
-            let startTime = batteryInfo.performanceInspectionResults[0].timestamp;
-            batteryInfo.performanceInspectionResults.forEach((inspectionResult) => {
+        if (androidBatteryInfo && androidBatteryInfo.performanceInspectionResults && androidBatteryInfo.performanceInspectionResults.length > 0) {
+            let startTime = androidBatteryInfo.performanceInspectionResults[0].timestamp;
+            androidBatteryInfo.performanceInspectionResults.forEach((inspectionResult) => {
                 if (inspectionResult.parsedData !== null) {
                     let result = { ...inspectionResult.parsedData };
                     result.time = (inspectionResult.timestamp - startTime) / 1000;
@@ -113,9 +113,9 @@ export default class PerfTestDashboard extends React.Component {
         /**
          * Memory Info
          */
-        if (memoryInfo && memoryInfo.performanceInspectionResults && memoryInfo.performanceInspectionResults.length > 0) {
-            let startTime = memoryInfo.performanceInspectionResults[0].timestamp;
-            memoryInfo.performanceInspectionResults.forEach((inspectionResult) => {
+        if (androidMemoryInfo && androidMemoryInfo.performanceInspectionResults && androidMemoryInfo.performanceInspectionResults.length > 0) {
+            let startTime = androidMemoryInfo.performanceInspectionResults[0].timestamp;
+            androidMemoryInfo.performanceInspectionResults.forEach((inspectionResult) => {
                 if (inspectionResult.parsedData !== null) {
                     let result = { ...inspectionResult.parsedData };
                     result.time = (inspectionResult.timestamp - startTime) / 1000;
@@ -222,12 +222,12 @@ export default class PerfTestDashboard extends React.Component {
 
 
         return <div id='perf_dashboard'>
-            {batteryInfo && <div>
+            {androidBatteryInfo && <div>
                 <h3> Battery report</h3>
                 {androidBatteryMultiSelect}
                 {renderAndroidBatteryChart}
             </div>}
-            {memoryInfo && <div>
+            {androidMemoryInfo && <div>
                 <h3> Memory report</h3>
                 {androidMemoryMultiSelect}
                 {renderAndroidMemoryChart}
@@ -247,9 +247,9 @@ export default class PerfTestDashboard extends React.Component {
             for (var info of res.data.content) {
                 console.log(info);
                 if (info.parserType == 'PARSER_ANDROID_BATTERY_INFO') {
-                    this.setState({ batteryInfo: info });
+                    this.setState({ androidBatteryInfo: info });
                 } else if (info.parserType == 'PARSER_ANDROID_MEMORY_INFO') {
-                    this.setState({ memoryInfo: info });
+                    this.setState({ androidMemoryInfo: info });
                 } else if (info.parserType == 'PARSER_WIN_MEMORY') {
                     this.setState({ windowsMemoryInfo: info });
                 }

--- a/react/src/component/PerfTestDashboard.jsx
+++ b/react/src/component/PerfTestDashboard.jsx
@@ -63,14 +63,14 @@ export default class PerfTestDashboard extends React.Component {
 
     render() {
         const androidMemoryInfo = this.state.androidMemoryInfo;
-        const memoryMetrics = [];
+        const androidMemoryMetrics = [];
         const androidBatteryInfo = this.state.androidBatteryInfo;
-        const batteryMetrics = [];
+        const androidBatteryMetrics = [];
         const windowsMemoryInfo = this.state.windowsMemoryInfo;
         const windowsMemoryMetrics = [];
 
         /**
-         * Battery Info
+         * Android Battery Info
          */
         if (androidBatteryInfo && androidBatteryInfo.performanceInspectionResults && androidBatteryInfo.performanceInspectionResults.length > 0) {
             let startTime = androidBatteryInfo.performanceInspectionResults[0].timestamp;
@@ -79,7 +79,7 @@ export default class PerfTestDashboard extends React.Component {
                     let result = { ...inspectionResult.parsedData };
                     result.time = (inspectionResult.timestamp - startTime) / 1000;
                     result.ratio = inspectionResult.parsedData.ratio * 100;
-                    batteryMetrics.push(result);
+                    androidBatteryMetrics.push(result);
                 }
             })
         }
@@ -97,7 +97,7 @@ export default class PerfTestDashboard extends React.Component {
         );
 
         const renderAndroidBatteryChart = (
-            <LineChart width={800} height={400} data={batteryMetrics} margin={{ top: 20, right: 100, bottom: 20, left: 20 }}>
+            <LineChart width={800} height={400} data={androidBatteryMetrics} margin={{ top: 20, right: 100, bottom: 20, left: 20 }}>
                 <XAxis dataKey="time" label={{ value: 'Time', position: 'bottom' }} unit="s" />
                 <YAxis yAxisId="left" label={{ value: 'Battery usage (mAh)', angle: -90, position: 'left' }} />
                 <YAxis yAxisId="right" label={{ value: 'Ratio', angle: -90, position: 'right' }} unit="%" orientation="right" />
@@ -111,7 +111,7 @@ export default class PerfTestDashboard extends React.Component {
 
 
         /**
-         * Memory Info
+         * Android Memory Info
          */
         if (androidMemoryInfo && androidMemoryInfo.performanceInspectionResults && androidMemoryInfo.performanceInspectionResults.length > 0) {
             let startTime = androidMemoryInfo.performanceInspectionResults[0].timestamp;
@@ -127,7 +127,7 @@ export default class PerfTestDashboard extends React.Component {
                             result[key] = inspectionResult.parsedData[key] / 1024;
                         }
                     })
-                    memoryMetrics.push(result);
+                    androidMemoryMetrics.push(result);
                 }
             })
         }
@@ -145,7 +145,7 @@ export default class PerfTestDashboard extends React.Component {
         );
 
         const renderAndroidMemoryChart = (
-            <LineChart width={800} height={400} data={memoryMetrics} margin={{ top: 20, right: 20, bottom: 20, left: 20 }}>
+            <LineChart width={800} height={400} data={androidMemoryMetrics} margin={{ top: 20, right: 20, bottom: 20, left: 20 }}>
                 <Legend verticalAlign="top" />
                 <XAxis dataKey="time" label={{ value: 'Time', position: 'bottom' }} unit="s" />
                 <YAxis yAxisId="left" label={{ value: 'Memory usage (MB)', angle: -90, position: 'left' }} />
@@ -223,12 +223,12 @@ export default class PerfTestDashboard extends React.Component {
 
         return <div id='perf_dashboard'>
             {androidBatteryInfo && <div>
-                <h3> Battery report</h3>
+                <h3> Android Battery report</h3>
                 {androidBatteryMultiSelect}
                 {renderAndroidBatteryChart}
             </div>}
             {androidMemoryInfo && <div>
-                <h3> Memory report</h3>
+                <h3> Android Memory report</h3>
                 {androidMemoryMultiSelect}
                 {renderAndroidMemoryChart}
             </div>}

--- a/react/src/component/PerfTestDashboard.jsx
+++ b/react/src/component/PerfTestDashboard.jsx
@@ -194,7 +194,6 @@ export default class PerfTestDashboard extends React.Component {
         }
 
         const windowsMemoryMultiSelect = (
-            // TODO
             <Select
                 defaultValue={windowsMemoryOptions}
                 isMulti
@@ -207,7 +206,6 @@ export default class PerfTestDashboard extends React.Component {
         );
 
         const renderWindowsMemoryChart = (
-            // TODO
             <LineChart width={800} height={400} data={windowsMemoryMetrics} margin={{ top: 20, right: 20, bottom: 20, left: 20 }}>
                 <Legend verticalAlign="top" />
                 <XAxis dataKey="time" label={{ value: 'Time', position: 'bottom' }} unit="s" />


### PR DESCRIPTION
## Description
<!-- Please write a brief information about PR, what it contains, its purpose -->
Add a new chart for Windows memory performance test.

## Screenshots
<!-- Please add screenshots -->
![image](https://user-images.githubusercontent.com/10386842/224941105-c9546dcf-d41b-4f64-89f5-e4cb4d9c10ce.png)

## Testing
Testing with the following json parameter:

"inspectionStrategies": [
    {
      "strategyType": "TEST_SCHEDULE",
      "interval": 5000,
      "intervalUnit": "MILLISECONDS",
      "inspection": {
        "inspectorType": "INSPECTOR_WIN_MEMORY",
        "appId": "com.microsoft.hydralab.android.client",
        "description": "testschedule"
      }
    }
  ]
