### PR TITLE
Add validation for ";" in file name for LOCAL storage upload/download

### DIFF
--- a/center/src/main/java/com/microsoft/hydralab/center/controller/StorageController.java
+++ b/center/src/main/java/com/microsoft/hydralab/center/controller/StorageController.java
@@ -57,7 +57,7 @@ public class StorageController {
             return Result.error(HttpStatus.UNAUTHORIZED.value(), "Unauthorized, error access token for storage actions.");
         }
         if (!LogUtils.isLegalStr(fileUri, Const.RegexString.STORAGE_FILE_REL_PATH, false)) {
-            return Result.error(HttpStatus.BAD_REQUEST.value(), "Invalid file path!");
+            return Result.error(HttpStatus.BAD_REQUEST.value(), "Invalid file path, file name should not include ';'!");
         }
 
         try {
@@ -90,7 +90,7 @@ public class StorageController {
             throw new HydraLabRuntimeException(HttpStatus.UNAUTHORIZED.value(), "Unauthorized, error access token for storage actions.");
         }
         if (!LogUtils.isLegalStr(fileUri, Const.RegexString.STORAGE_FILE_REL_PATH, false)) {
-            throw new HydraLabRuntimeException(HttpStatus.BAD_REQUEST.value(), "Invalid file path!");
+            throw new HydraLabRuntimeException(HttpStatus.BAD_REQUEST.value(), "Invalid file path, file name should not include ';'!");
         }
 
         File file = new File(Const.LocalStorageURL.CENTER_LOCAL_STORAGE_ROOT + fileUri);
@@ -128,7 +128,7 @@ public class StorageController {
         final String bestMatchingPattern = request.getAttribute(HandlerMapping.BEST_MATCHING_PATTERN_ATTRIBUTE).toString();
         String fileUri = new AntPathMatcher().extractPathWithinPattern(bestMatchingPattern, appendPath);
         if (!LogUtils.isLegalStr(fileUri, Const.RegexString.STORAGE_FILE_REL_PATH, false)) {
-            throw new HydraLabRuntimeException(HttpStatus.BAD_REQUEST.value(), "Invalid file path!");
+            throw new HydraLabRuntimeException(HttpStatus.BAD_REQUEST.value(), "Invalid file path, file name should not include ';'!");
         }
 
         File file = new File(Const.LocalStorageURL.CENTER_LOCAL_STORAGE_ROOT + fileUri);

--- a/common/src/main/java/com/microsoft/hydralab/common/util/Const.java
+++ b/common/src/main/java/com/microsoft/hydralab/common/util/Const.java
@@ -111,7 +111,7 @@ public interface Const {
         // There are almost no restrictions - apart from '/' and '\0', you're allowed to use anything. Hence the below is only an adoption for the most cases
         String LINUX_ABSOLUTE_PATH = "^(\\/[^\\t\\f\\n\\r\\v]+)+\\/?$";
         String WINDOWS_ABSOLUTE_PATH = "^([a-zA-Z]:)(\\\\[^/\\\\:*?\"<>|]+\\\\?)*$";
-        String STORAGE_FILE_REL_PATH = "^[^\\/\\\\:*?\"<>|]+(\\/[^\\/\\\\:*?\"<>|]+)+$";
+        String STORAGE_FILE_REL_PATH = "^([^\\/\\\\:*?\"<>|]+\\/)+[^\\/\\\\:*?\"<>|;]+$";
 
         //Package name
         String PACKAGE_NAME = "\\w+([-.]\\w+)*\\.\\w+([-.]\\w+)*";


### PR DESCRIPTION
## Pull Request Checklist
<!-- Put an x in the boxes that apply. This is simply a reminder of what we are going to look for before merging your code. -->

- [X] Tests for the changes have been added (for bug fixes / features)
- [x] Code compiles correctly with all tests are passed.
- [x] I've read the [contributing guide](https://github.com/microsoft/HydraLab/blob/main/CONTRIBUTING.md#making-changes-to-the-code) and followed the recommended practices.
- [x] [Wikis](https://github.com/microsoft/HydraLab/wiki) or [README](https://github.com/microsoft/HydraLab/blob/main/README.md) have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
*If this introduces a breaking change for Hydra Lab users, please describe the impact and migration path.*

- [ ] Yes
- [x] No

## Pull Request Description

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Build related changes
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Code style update (formatting, renaming) or Documentation content changes
- [ ] Other (please describe): 

**A few words to explain your changes**:
<!-- Please write a brief information about the PR, what it contains & its purpose, new behaviors after the change -->

According to https://cloud.tencent.com/developer/section/1189916, file name as input should include no ";", otherwise file name will be cut down to the first part of the file name before";".


### How you tested it
Locally tested, the updated regex is working.

### Feature UI screenshots or Technical design diagrams
*If this is a relatively large or complex change, kick it off by drawing the tech design with PlantUML and explaining why you chose the solution you did and what alternatives you considered, etc...*



