### PR TITLE
Fix gradle plugin log typo

### DIFF
--- a/gradle_plugin/build.gradle
+++ b/gradle_plugin/build.gradle
@@ -37,7 +37,7 @@ dependencies {
 }
 
 // plugin publishing related
-version = '1.1.4'
+version = '1.1.5'
 group = 'com.microsoft.hydralab'
 // alter group to this when publish to local, in order to distinguish local version and gradle plugin portal version
 //group = 'com.microsoft.hydralab.local'

--- a/gradle_plugin/src/main/groovy/com/microsoft/hydralab/ClientUtilsPlugin.groovy
+++ b/gradle_plugin/src/main/groovy/com/microsoft/hydralab/ClientUtilsPlugin.groovy
@@ -165,7 +165,7 @@ class ClientUtilsPlugin implements Plugin<Project> {
                 || testConfig.runTimeOutSeconds == 0
                 || StringUtils.isBlank(testConfig.deviceConfig.deviceIdentifier)
         ) {
-            throw new IllegalArgumentException('Required params not provided! Make sure the following params are all provided correctly: hydraLabAPIhost, authToken, deviceIdentifier, appPath, pkgName, runningType, runTimeOutSeconds.')
+            throw new IllegalArgumentException('Required params not provided! Make sure the following params are all provided correctly: hydraLabAPIHost, authToken, deviceIdentifier, appPath, pkgName, runningType, runTimeOutSeconds.')
         }
 
         // running type specified params

--- a/gradle_plugin/src/test/java/com/microsoft/hydralab/ClientUtilsPluginTest.java
+++ b/gradle_plugin/src/test/java/com/microsoft/hydralab/ClientUtilsPluginTest.java
@@ -244,7 +244,7 @@ public class ClientUtilsPluginTest {
         IllegalArgumentException thrown = Assertions.assertThrows(IllegalArgumentException.class, () -> {
             clientUtilsPlugin.requiredParamCheck(apiConfig, testConfig);
         }, "IllegalArgumentException was expected");
-        Assertions.assertEquals("Required params not provided! Make sure the following params are all provided correctly: hydraLabAPIhost, authToken, deviceIdentifier, appPath, pkgName, runningType, runTimeOutSeconds.", thrown.getMessage());
+        Assertions.assertEquals("Required params not provided! Make sure the following params are all provided correctly: hydraLabAPIHost, authToken, deviceIdentifier, appPath, pkgName, runningType, runTimeOutSeconds.", thrown.getMessage());
     }
 
     private void typeSpecificParamCheck(HydraLabAPIConfig apiConfig, TestConfig testConfig, String requiredParamName) {


### PR DESCRIPTION
- Version upgraded to 1.1.5;

<!-- Please refer to our contributing documentation for making changes to the code of Hydra Lab https://github.com/microsoft/HydraLab/blob/main/CONTRIBUTING.md#making-changes-to-the-code , or let us know here if you need any help: https://github.com/microsoft/HydraLab/issues/new -->

## Pull Request Checklist
<!-- Put an x in the boxes that apply. This is simply a reminder of what we are going to look for before merging your code. -->

- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Code compiles correctly with all tests are passed.
- [X] I've read the [contributing guide](https://github.com/microsoft/HydraLab/blob/main/CONTRIBUTING.md#making-changes-to-the-code) and followed the recommended practices.
- [X] [Wikis](https://github.com/microsoft/HydraLab/wiki) or [README](https://github.com/microsoft/HydraLab/blob/main/README.md) have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
*If this introduces a breaking change for Hydra Lab users, please describe the impact and migration path.*

- [ ] Yes
- [X] No

## Pull Request Description

Please check the type of change your PR introduces:
- [X] Bugfix
- [ ] Feature
- [ ] Build related changes
- [ ] Refactoring (no functional changes, no api changes)
- [X] Code style update (formatting, renaming) or Documentation content changes
- [ ] Other (please describe): 

**A few words to explain your changes**:
<!-- Please write a brief information about the PR, what it contains & its purpose, new behaviors after the change -->

The param hydraLabAPIHost in log showed as hydraLabAPIhost, which may confuse users.

### How you tested it
Log change, not tested

### Feature UI screenshots or Technical design diagrams
*If this is a relatively large or complex change, kick it off by drawing the tech design with PlantUML and explaining why you chose the solution you did and what alternatives you considered, etc...*



