### PR TITLE
[Perf] Implement perf summary and history for iOS performance test

### DIFF
--- a/common/src/main/java/com/microsoft/hydralab/performance/entity/IOSEnergyGaugeInfo.java
+++ b/common/src/main/java/com/microsoft/hydralab/performance/entity/IOSEnergyGaugeInfo.java
@@ -79,6 +79,6 @@ public class IOSEnergyGaugeInfo implements Serializable, IBaselineMetrics {
     @Override
     @JSONField(serialize = false)
     public SummaryType getSummaryType() {
-        return SummaryType.SUM;
+        return SummaryType.AVERAGE;
     }
 }

--- a/common/src/main/java/com/microsoft/hydralab/performance/entity/IOSEnergyGaugeInfo.java
+++ b/common/src/main/java/com/microsoft/hydralab/performance/entity/IOSEnergyGaugeInfo.java
@@ -67,12 +67,18 @@ public class IOSEnergyGaugeInfo implements Serializable, IBaselineMetrics {
     @Override
     @JSONField(serialize = false)
     public LinkedHashMap<String, Double> getBaselineMetricsKeyValue() {
-        return null;
+        LinkedHashMap<String, Double> baselineMap = new LinkedHashMap<>();
+        baselineMap.put("totalCost", (double) totalCost);
+        baselineMap.put("cpuCost", (double) cpuCost);
+        baselineMap.put("networkingCost", (double) networkingCost);
+        baselineMap.put("appStateCost", (double) appStateCost);
+        baselineMap.put("locationCost", (double) locationCost);
+        return baselineMap;
     }
 
     @Override
     @JSONField(serialize = false)
     public SummaryType getSummaryType() {
-        return null;
+        return SummaryType.SUM;
     }
 }

--- a/common/src/main/java/com/microsoft/hydralab/performance/entity/IOSMemoryPerfInfo.java
+++ b/common/src/main/java/com/microsoft/hydralab/performance/entity/IOSMemoryPerfInfo.java
@@ -24,12 +24,14 @@ public class IOSMemoryPerfInfo implements Serializable, IBaselineMetrics {
     @Override
     @JSONField(serialize = false)
     public LinkedHashMap<String, Double> getBaselineMetricsKeyValue() {
-        return null;
+        LinkedHashMap<String, Double> baselineMap = new LinkedHashMap<>();
+        baselineMap.put("memoryMB", (double) memoryMB);
+        return baselineMap;
     }
 
     @Override
     @JSONField(serialize = false)
     public SummaryType getSummaryType() {
-        return null;
+        return SummaryType.AVERAGE;
     }
 }

--- a/common/src/main/java/com/microsoft/hydralab/performance/parsers/IOSEnergyGaugeResultParser.java
+++ b/common/src/main/java/com/microsoft/hydralab/performance/parsers/IOSEnergyGaugeResultParser.java
@@ -74,7 +74,9 @@ public class IOSEnergyGaugeResultParser implements PerformanceResultParser {
                         lineNumber++;
                     }
                     performanceTestResult.performanceInspectionResults = newPerfInspectionResults;
-//                    performanceTestResult.setResultSummary(getSumIOSEnergy(newPerfInspectionResults));
+
+                    // Uncomment the following line to get the sum of the energy consumption
+                    // performanceTestResult.setResultSummary(getSumIOSEnergy(newPerfInspectionResults));
                     performanceTestResult.setResultSummary(getAverageIOSEnergy(newPerfInspectionResults));
                     oldInspectionResults.clear();
                 } catch (IOException e) {
@@ -90,31 +92,31 @@ public class IOSEnergyGaugeResultParser implements PerformanceResultParser {
             return null;
         }
 
-        IOSEnergyGaugeInfo sumEnergyInfo = new IOSEnergyGaugeInfo();
-        sumEnergyInfo.setAppPackageName(inspectionResults.get(0).inspection.appId);
-        sumEnergyInfo.setTimeStamp(System.currentTimeMillis());
+        IOSEnergyGaugeInfo averageEnergyInfo = new IOSEnergyGaugeInfo();
+        averageEnergyInfo.setAppPackageName(inspectionResults.get(0).inspection.appId);
+        averageEnergyInfo.setTimeStamp(System.currentTimeMillis());
 
         for (int i = 0; i < inspectionResults.size(); i++) {
             PerformanceInspectionResult result = inspectionResults.get(i);
             IOSEnergyGaugeInfo energyInfo = (IOSEnergyGaugeInfo) result.parsedData;
-            sumEnergyInfo.setTotalCost(sumEnergyInfo.getTotalCost() * i / (i + 1) + energyInfo.getTotalCost() / (i + 1));
-            sumEnergyInfo.setCpuCost(sumEnergyInfo.getCpuCost() * i / (i + 1) + energyInfo.getCpuCost() / (i + 1));
-            sumEnergyInfo.setGpuCost(sumEnergyInfo.getGpuCost() * i / (i + 1) + energyInfo.getGpuCost() / (i + 1));
-            sumEnergyInfo.setNetworkingCost(sumEnergyInfo.getNetworkingCost() * i / (i + 1) + energyInfo.getNetworkingCost() / (i + 1));
-            sumEnergyInfo.setAppStateCost(sumEnergyInfo.getAppStateCost() * i / (i + 1) + energyInfo.getAppStateCost() / (i + 1));
-            sumEnergyInfo.setLocationCost(sumEnergyInfo.getLocationCost() * i / (i + 1) + energyInfo.getLocationCost() / (i + 1));
-            sumEnergyInfo.setThermalStateCost(sumEnergyInfo.getThermalStateCost() * i / (i + 1) + energyInfo.getThermalStateCost() / (i + 1));
+            averageEnergyInfo.setTotalCost(averageEnergyInfo.getTotalCost() * i / (i + 1) + energyInfo.getTotalCost() / (i + 1));
+            averageEnergyInfo.setCpuCost(averageEnergyInfo.getCpuCost() * i / (i + 1) + energyInfo.getCpuCost() / (i + 1));
+            averageEnergyInfo.setGpuCost(averageEnergyInfo.getGpuCost() * i / (i + 1) + energyInfo.getGpuCost() / (i + 1));
+            averageEnergyInfo.setNetworkingCost(averageEnergyInfo.getNetworkingCost() * i / (i + 1) + energyInfo.getNetworkingCost() / (i + 1));
+            averageEnergyInfo.setAppStateCost(averageEnergyInfo.getAppStateCost() * i / (i + 1) + energyInfo.getAppStateCost() / (i + 1));
+            averageEnergyInfo.setLocationCost(averageEnergyInfo.getLocationCost() * i / (i + 1) + energyInfo.getLocationCost() / (i + 1));
+            averageEnergyInfo.setThermalStateCost(averageEnergyInfo.getThermalStateCost() * i / (i + 1) + energyInfo.getThermalStateCost() / (i + 1));
 
-            sumEnergyInfo.setTotalOverhead(sumEnergyInfo.getTotalOverhead() * i / (i + 1) + energyInfo.getTotalOverhead() / (i + 1));
-            sumEnergyInfo.setCpuOverhead(sumEnergyInfo.getCpuOverhead() * i / (i + 1) + energyInfo.getCpuOverhead() / (i + 1));
-            sumEnergyInfo.setGpuOverhead(sumEnergyInfo.getGpuOverhead() * i / (i + 1) + energyInfo.getGpuOverhead() / (i + 1));
-            sumEnergyInfo.setNetworkingOverhead(sumEnergyInfo.getNetworkingOverhead() * i / (i + 1) + energyInfo.getNetworkingOverhead() / (i + 1));
-            sumEnergyInfo.setAppStateOverhead(sumEnergyInfo.getAppStateOverhead() * i / (i + 1) + energyInfo.getAppStateOverhead() / (i + 1));
-            sumEnergyInfo.setLocationOverhead(sumEnergyInfo.getLocationOverhead() * i / (i + 1) + energyInfo.getLocationOverhead() / (i + 1));
-            sumEnergyInfo.setThermalStateOverhead(sumEnergyInfo.getThermalStateOverhead() * i / (i + 1) + energyInfo.getThermalStateOverhead() / (i + 1));
+            averageEnergyInfo.setTotalOverhead(averageEnergyInfo.getTotalOverhead() * i / (i + 1) + energyInfo.getTotalOverhead() / (i + 1));
+            averageEnergyInfo.setCpuOverhead(averageEnergyInfo.getCpuOverhead() * i / (i + 1) + energyInfo.getCpuOverhead() / (i + 1));
+            averageEnergyInfo.setGpuOverhead(averageEnergyInfo.getGpuOverhead() * i / (i + 1) + energyInfo.getGpuOverhead() / (i + 1));
+            averageEnergyInfo.setNetworkingOverhead(averageEnergyInfo.getNetworkingOverhead() * i / (i + 1) + energyInfo.getNetworkingOverhead() / (i + 1));
+            averageEnergyInfo.setAppStateOverhead(averageEnergyInfo.getAppStateOverhead() * i / (i + 1) + energyInfo.getAppStateOverhead() / (i + 1));
+            averageEnergyInfo.setLocationOverhead(averageEnergyInfo.getLocationOverhead() * i / (i + 1) + energyInfo.getLocationOverhead() / (i + 1));
+            averageEnergyInfo.setThermalStateOverhead(averageEnergyInfo.getThermalStateOverhead() * i / (i + 1) + energyInfo.getThermalStateOverhead() / (i + 1));
         }
 
-        return sumEnergyInfo;
+        return averageEnergyInfo;
     }
 
     private IOSEnergyGaugeInfo getSumIOSEnergy(List<PerformanceInspectionResult> inspectionResults) {

--- a/common/src/main/java/com/microsoft/hydralab/performance/parsers/IOSEnergyGaugeResultParser.java
+++ b/common/src/main/java/com/microsoft/hydralab/performance/parsers/IOSEnergyGaugeResultParser.java
@@ -74,6 +74,7 @@ public class IOSEnergyGaugeResultParser implements PerformanceResultParser {
                         lineNumber++;
                     }
                     performanceTestResult.performanceInspectionResults = newPerfInspectionResults;
+                    performanceTestResult.setResultSummary(getSumIOSEnergy(newPerfInspectionResults));
                     oldInspectionResults.clear();
                 } catch (IOException e) {
                     throw new RuntimeException(e);
@@ -81,5 +82,36 @@ public class IOSEnergyGaugeResultParser implements PerformanceResultParser {
             }
         }
         return performanceTestResult;
+    }
+
+    private IOSEnergyGaugeInfo getSumIOSEnergy(List<PerformanceInspectionResult> inspectionResults) {
+        if (inspectionResults == null || inspectionResults.size() == 0) {
+            return null;
+        }
+
+        IOSEnergyGaugeInfo sumEnergyInfo = new IOSEnergyGaugeInfo();
+        sumEnergyInfo.setAppPackageName(inspectionResults.get(0).inspection.appId);
+        sumEnergyInfo.setTimeStamp(System.currentTimeMillis());
+
+        for (PerformanceInspectionResult result : inspectionResults) {
+            IOSEnergyGaugeInfo energyInfo = (IOSEnergyGaugeInfo) result.parsedData;
+            sumEnergyInfo.setTotalCost(sumEnergyInfo.getTotalCost() + energyInfo.getTotalCost());
+            sumEnergyInfo.setCpuCost(sumEnergyInfo.getCpuCost() + energyInfo.getCpuCost());
+            sumEnergyInfo.setGpuCost(sumEnergyInfo.getGpuCost() + energyInfo.getGpuCost());
+            sumEnergyInfo.setNetworkingCost(sumEnergyInfo.getNetworkingCost() + energyInfo.getNetworkingCost());
+            sumEnergyInfo.setAppStateCost(sumEnergyInfo.getAppStateCost() + energyInfo.getAppStateCost());
+            sumEnergyInfo.setLocationCost(sumEnergyInfo.getLocationCost() + energyInfo.getLocationCost());
+            sumEnergyInfo.setThermalStateCost(sumEnergyInfo.getThermalStateCost() + energyInfo.getThermalStateCost());
+
+            sumEnergyInfo.setTotalOverhead(sumEnergyInfo.getTotalOverhead() + energyInfo.getTotalOverhead());
+            sumEnergyInfo.setCpuOverhead(sumEnergyInfo.getCpuOverhead() + energyInfo.getCpuOverhead());
+            sumEnergyInfo.setGpuOverhead(sumEnergyInfo.getGpuOverhead() + energyInfo.getGpuOverhead());
+            sumEnergyInfo.setNetworkingOverhead(sumEnergyInfo.getNetworkingOverhead() + energyInfo.getNetworkingOverhead());
+            sumEnergyInfo.setAppStateOverhead(sumEnergyInfo.getAppStateOverhead() + energyInfo.getAppStateOverhead());
+            sumEnergyInfo.setLocationOverhead(sumEnergyInfo.getLocationOverhead() + energyInfo.getLocationOverhead());
+            sumEnergyInfo.setThermalStateOverhead(sumEnergyInfo.getThermalStateOverhead() + energyInfo.getThermalStateOverhead());
+        }
+
+        return sumEnergyInfo;
     }
 }

--- a/common/src/main/java/com/microsoft/hydralab/performance/parsers/IOSEnergyGaugeResultParser.java
+++ b/common/src/main/java/com/microsoft/hydralab/performance/parsers/IOSEnergyGaugeResultParser.java
@@ -74,7 +74,8 @@ public class IOSEnergyGaugeResultParser implements PerformanceResultParser {
                         lineNumber++;
                     }
                     performanceTestResult.performanceInspectionResults = newPerfInspectionResults;
-                    performanceTestResult.setResultSummary(getSumIOSEnergy(newPerfInspectionResults));
+//                    performanceTestResult.setResultSummary(getSumIOSEnergy(newPerfInspectionResults));
+                    performanceTestResult.setResultSummary(getAverageIOSEnergy(newPerfInspectionResults));
                     oldInspectionResults.clear();
                 } catch (IOException e) {
                     throw new RuntimeException(e);
@@ -82,6 +83,38 @@ public class IOSEnergyGaugeResultParser implements PerformanceResultParser {
             }
         }
         return performanceTestResult;
+    }
+
+    private IOSEnergyGaugeInfo getAverageIOSEnergy(List<PerformanceInspectionResult> inspectionResults) {
+        if (inspectionResults == null || inspectionResults.size() == 0) {
+            return null;
+        }
+
+        IOSEnergyGaugeInfo sumEnergyInfo = new IOSEnergyGaugeInfo();
+        sumEnergyInfo.setAppPackageName(inspectionResults.get(0).inspection.appId);
+        sumEnergyInfo.setTimeStamp(System.currentTimeMillis());
+
+        for (int i = 0; i < inspectionResults.size(); i++) {
+            PerformanceInspectionResult result = inspectionResults.get(i);
+            IOSEnergyGaugeInfo energyInfo = (IOSEnergyGaugeInfo) result.parsedData;
+            sumEnergyInfo.setTotalCost(sumEnergyInfo.getTotalCost() * i / (i + 1) + energyInfo.getTotalCost() / (i + 1));
+            sumEnergyInfo.setCpuCost(sumEnergyInfo.getCpuCost() * i / (i + 1) + energyInfo.getCpuCost() / (i + 1));
+            sumEnergyInfo.setGpuCost(sumEnergyInfo.getGpuCost() * i / (i + 1) + energyInfo.getGpuCost() / (i + 1));
+            sumEnergyInfo.setNetworkingCost(sumEnergyInfo.getNetworkingCost() * i / (i + 1) + energyInfo.getNetworkingCost() / (i + 1));
+            sumEnergyInfo.setAppStateCost(sumEnergyInfo.getAppStateCost() * i / (i + 1) + energyInfo.getAppStateCost() / (i + 1));
+            sumEnergyInfo.setLocationCost(sumEnergyInfo.getLocationCost() * i / (i + 1) + energyInfo.getLocationCost() / (i + 1));
+            sumEnergyInfo.setThermalStateCost(sumEnergyInfo.getThermalStateCost() * i / (i + 1) + energyInfo.getThermalStateCost() / (i + 1));
+
+            sumEnergyInfo.setTotalOverhead(sumEnergyInfo.getTotalOverhead() * i / (i + 1) + energyInfo.getTotalOverhead() / (i + 1));
+            sumEnergyInfo.setCpuOverhead(sumEnergyInfo.getCpuOverhead() * i / (i + 1) + energyInfo.getCpuOverhead() / (i + 1));
+            sumEnergyInfo.setGpuOverhead(sumEnergyInfo.getGpuOverhead() * i / (i + 1) + energyInfo.getGpuOverhead() / (i + 1));
+            sumEnergyInfo.setNetworkingOverhead(sumEnergyInfo.getNetworkingOverhead() * i / (i + 1) + energyInfo.getNetworkingOverhead() / (i + 1));
+            sumEnergyInfo.setAppStateOverhead(sumEnergyInfo.getAppStateOverhead() * i / (i + 1) + energyInfo.getAppStateOverhead() / (i + 1));
+            sumEnergyInfo.setLocationOverhead(sumEnergyInfo.getLocationOverhead() * i / (i + 1) + energyInfo.getLocationOverhead() / (i + 1));
+            sumEnergyInfo.setThermalStateOverhead(sumEnergyInfo.getThermalStateOverhead() * i / (i + 1) + energyInfo.getThermalStateOverhead() / (i + 1));
+        }
+
+        return sumEnergyInfo;
     }
 
     private IOSEnergyGaugeInfo getSumIOSEnergy(List<PerformanceInspectionResult> inspectionResults) {

--- a/common/src/main/java/com/microsoft/hydralab/performance/parsers/IOSMemoryPerfResultParser.java
+++ b/common/src/main/java/com/microsoft/hydralab/performance/parsers/IOSMemoryPerfResultParser.java
@@ -21,6 +21,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
 
 public class IOSMemoryPerfResultParser implements PerformanceResultParser {
     protected Logger classLogger = LoggerFactory.getLogger(getClass());
+
     @Override
     public PerformanceTestResult parse(PerformanceTestResult performanceTestResult) {
         int inspectionSize = performanceTestResult.performanceInspectionResults.size();
@@ -73,6 +74,7 @@ public class IOSMemoryPerfResultParser implements PerformanceResultParser {
                         }
                     }
                     performanceTestResult.performanceInspectionResults = newPerfInspectionResults;
+                    performanceTestResult.setResultSummary(getAverageIOSMemoryPerfInfo(newPerfInspectionResults));
                     oldInspectionResults.clear();
                 } catch (IOException e) {
                     throw new RuntimeException(e);
@@ -80,5 +82,22 @@ public class IOSMemoryPerfResultParser implements PerformanceResultParser {
             }
         }
         return performanceTestResult;
+    }
+
+    private IOSMemoryPerfInfo getAverageIOSMemoryPerfInfo(List<PerformanceInspectionResult> inspectionResults) {
+        if (inspectionResults == null || inspectionResults.size() == 0) {
+            return null;
+        }
+
+        IOSMemoryPerfInfo averageIOSMemoryPerfInfo = new IOSMemoryPerfInfo();
+        averageIOSMemoryPerfInfo.setAppPackageName(inspectionResults.get(0).inspection.appId);
+        averageIOSMemoryPerfInfo.setTimeStamp(System.currentTimeMillis());
+        double averageMemoryMB = 0;
+        for (int i = 0; i < inspectionResults.size(); i++) {
+            double memoryMB = ((IOSMemoryPerfInfo) (inspectionResults.get(i).parsedData)).getMemoryMB();
+            averageMemoryMB = memoryMB / (i + 1) + averageMemoryMB * i / (i + 1);
+        }
+        averageIOSMemoryPerfInfo.setMemoryMB((float) averageMemoryMB);
+        return averageIOSMemoryPerfInfo;
     }
 }

--- a/sdk/src/main/java/com/microsoft/hydralab/performance/IBaselineMetrics.java
+++ b/sdk/src/main/java/com/microsoft/hydralab/performance/IBaselineMetrics.java
@@ -10,6 +10,7 @@ public interface IBaselineMetrics {
 
     enum SummaryType {
         AVERAGE,
-        MAX
+        MAX,
+        SUM
     }
 }


### PR DESCRIPTION
<!-- Please provide brief information about the PR, what it contains & its purpose, new behaviors after the change. And let us know here if you need any help: https://github.com/microsoft/HydraLab/issues/new -->

**Linked GitHub issue ID**: #  

## Pull Request Checklist
<!-- Put an x in the boxes that apply. This is simply a reminder of what we are going to look for before merging your code. -->

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Code compiles correctly with all tests are passed.
- [ ] I've read the [contributing guide](https://github.com/microsoft/HydraLab/blob/main/CONTRIBUTING.md#making-changes-to-the-code) and followed the recommended practices.
- [ ] [Wikis](https://github.com/microsoft/HydraLab/wiki) or [README](https://github.com/microsoft/HydraLab/blob/main/README.md) have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
*If this introduces a breaking change for Hydra Lab users, please describe the impact and migration path.*

- [ ] Yes
- [x] No

## Pull Request Description

**A few words to explain your changes**:  

### How you tested it
*Please make sure the change is tested, you can test it by adding UTs, do local test and share the screenshots, etc.*


Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Technical design
- [ ] Build related changes
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Code style update (formatting, renaming) or Documentation content changes
- [ ] Other (please describe): 

### Feature UI screenshots or Technical design diagrams
*If this is a relatively large or complex change, kick it off by drawing the tech design with PlantUML and explaining why you chose the solution you did and what alternatives you considered, etc...*
![image](https://user-images.githubusercontent.com/30514480/232987931-baca198f-9224-483f-a968-a87d4adc737b.png)
