### PR TITLE
[Front-end] [Perf] Add device info to the Perf dashboard

### DIFF
--- a/react/src/component/PerfTestDashboard.jsx
+++ b/react/src/component/PerfTestDashboard.jsx
@@ -144,7 +144,7 @@ export default class PerfTestDashboard extends React.Component {
 
         if (isAndroidBatteryInfoEnabled) {
             let startTime = androidBatteryInfo.performanceInspectionResults[0].timestamp;
-            androidBatteryDevice = androidBatteryInfo.performanceInspectionResults[0].inspection.deviceIdentifier;
+            androidBatteryDevice = androidBatteryInfo.performanceInspectionResults[0].inspection && androidBatteryInfo.performanceInspectionResults[0].inspection.deviceIdentifier;
             androidBatteryInfo.performanceInspectionResults.forEach((inspectionResult) => {
                 if (inspectionResult && inspectionResult.parsedData) {
                     let result = { ...inspectionResult.parsedData };
@@ -194,7 +194,7 @@ export default class PerfTestDashboard extends React.Component {
 
         if (isAndroidMemoryInfoEnabled) {
             let startTime = androidMemoryInfo.performanceInspectionResults[0].timestamp;
-            androidMemoryDevice = androidMemoryInfo.performanceInspectionResults[0].inspection.deviceIdentifier;
+            androidMemoryDevice = androidMemoryInfo.performanceInspectionResults[0].inspection && androidMemoryInfo.performanceInspectionResults[0].inspection.deviceIdentifier;
             androidMemoryInfo.performanceInspectionResults.forEach((inspectionResult) => {
                 if (inspectionResult && inspectionResult.parsedData) {
                     let result = { ...inspectionResult.parsedData };
@@ -249,7 +249,7 @@ export default class PerfTestDashboard extends React.Component {
 
         if (isWindowsMemoryInfoEnabled) {
             let startTime = windowsMemoryInfo.performanceInspectionResults[0].timestamp;
-            windowsMemoryDevice = windowsMemoryInfo.performanceInspectionResults[0].inspection.deviceIdentifier;
+            windowsMemoryDevice = windowsMemoryInfo.performanceInspectionResults[0].inspection && windowsMemoryInfo.performanceInspectionResults[0].inspection.deviceIdentifier;
             windowsMemoryInfo.performanceInspectionResults.forEach((inspectionResult) => {
 
                 if (inspectionResult && inspectionResult.parsedData) {
@@ -318,7 +318,7 @@ export default class PerfTestDashboard extends React.Component {
 
         if (iosEnergyInfo && iosEnergyInfo.performanceInspectionResults && iosEnergyInfo.performanceInspectionResults.length > 0) {
             let startTime = iosEnergyInfo.performanceInspectionResults[0].timestamp;
-            iOSEnergyDevice = iosEnergyInfo.performanceInspectionResults[0].inspection.deviceIdentifier;
+            iOSEnergyDevice = iosEnergyInfo.performanceInspectionResults[0].inspection && iosEnergyInfo.performanceInspectionResults[0].inspection.deviceIdentifier;
             iosEnergyInfo.performanceInspectionResults.forEach((inspectionResult) => {
                 if (inspectionResult && inspectionResult.parsedData) {
                     var result = { ...inspectionResult.parsedData };
@@ -326,8 +326,6 @@ export default class PerfTestDashboard extends React.Component {
                     result.time = (inspectionResult.timestamp - startTime) / 1000;
                     isIosEnergyInfoEmpty = false;
                     result.testCase = inspectionResult.testCaseName;
-                    iOSEnergyDevice = inspectionResult.deviceIdentifier;
-
                     iosEnergyMetrics.push(result);
                 }
             })
@@ -369,7 +367,7 @@ export default class PerfTestDashboard extends React.Component {
 
         if (iosMemoryInfo && iosMemoryInfo.performanceInspectionResults && iosMemoryInfo.performanceInspectionResults.length > 0) {
             let startTime = iosMemoryInfo.performanceInspectionResults[0].timestamp;
-            iOSMemoryDevice = iosMemoryInfo.performanceInspectionResults[0].inspection.deviceIdentifier;
+            iOSMemoryDevice = iosMemoryInfo.performanceInspectionResults[0].inspection && iosMemoryInfo.performanceInspectionResults[0].inspection.deviceIdentifier;
             iosMemoryInfo.performanceInspectionResults.forEach((inspectionResult) => {
                 if (inspectionResult && inspectionResult.parsedData) {
                     var result = { ...inspectionResult.parsedData };

--- a/react/src/component/PerfTestDashboard.jsx
+++ b/react/src/component/PerfTestDashboard.jsx
@@ -140,9 +140,11 @@ export default class PerfTestDashboard extends React.Component {
          */
         var isAndroidBatteryInfoEnabled = androidBatteryInfo && androidBatteryInfo.performanceInspectionResults && androidBatteryInfo.performanceInspectionResults.length > 0
         var isAndroidBatteryInfoEmpty = true
+        var androidBatteryDevice = undefined;
 
         if (isAndroidBatteryInfoEnabled) {
             let startTime = androidBatteryInfo.performanceInspectionResults[0].timestamp;
+            androidBatteryDevice = androidBatteryInfo.performanceInspectionResults[0].inspection.deviceIdentifier;
             androidBatteryInfo.performanceInspectionResults.forEach((inspectionResult) => {
                 if (inspectionResult && inspectionResult.parsedData) {
                     let result = { ...inspectionResult.parsedData };
@@ -188,9 +190,11 @@ export default class PerfTestDashboard extends React.Component {
          */
         var isAndroidMemoryInfoEnabled = androidMemoryInfo && androidMemoryInfo.performanceInspectionResults && androidMemoryInfo.performanceInspectionResults.length > 0
         var isAndroidMemoryInfoEmpty = true;
+        var androidMemoryDevice = undefined;
 
         if (isAndroidMemoryInfoEnabled) {
             let startTime = androidMemoryInfo.performanceInspectionResults[0].timestamp;
+            androidMemoryDevice = androidMemoryInfo.performanceInspectionResults[0].inspection.deviceIdentifier;
             androidMemoryInfo.performanceInspectionResults.forEach((inspectionResult) => {
                 if (inspectionResult && inspectionResult.parsedData) {
                     let result = { ...inspectionResult.parsedData };
@@ -241,9 +245,11 @@ export default class PerfTestDashboard extends React.Component {
          */
         var isWindowsMemoryInfoEnabled = windowsMemoryInfo && windowsMemoryInfo.performanceInspectionResults && windowsMemoryInfo.performanceInspectionResults.length > 0
         var isWindowsMemoryInfoEmpty = true;
+        var windowsMemoryDevice = undefined;
 
         if (isWindowsMemoryInfoEnabled) {
             let startTime = windowsMemoryInfo.performanceInspectionResults[0].timestamp;
+            windowsMemoryDevice = windowsMemoryInfo.performanceInspectionResults[0].inspection.deviceIdentifier;
             windowsMemoryInfo.performanceInspectionResults.forEach((inspectionResult) => {
 
                 if (inspectionResult && inspectionResult.parsedData) {
@@ -308,17 +314,19 @@ export default class PerfTestDashboard extends React.Component {
          */
         var isIosEnergyEnabled = iosEnergyInfo && iosEnergyInfo.performanceInspectionResults && iosEnergyInfo.performanceInspectionResults.length > 0
         var isIosEnergyInfoEmpty = true;
+        var iOSEnergyDevice = undefined;
 
         if (iosEnergyInfo && iosEnergyInfo.performanceInspectionResults && iosEnergyInfo.performanceInspectionResults.length > 0) {
             let startTime = iosEnergyInfo.performanceInspectionResults[0].timestamp;
+            iOSEnergyDevice = iosEnergyInfo.performanceInspectionResults[0].inspection.deviceIdentifier;
             iosEnergyInfo.performanceInspectionResults.forEach((inspectionResult) => {
-
                 if (inspectionResult && inspectionResult.parsedData) {
                     var result = { ...inspectionResult.parsedData };
                     let parsedData = { ...inspectionResult.parsedData };
                     result.time = (inspectionResult.timestamp - startTime) / 1000;
                     isIosEnergyInfoEmpty = false;
                     result.testCase = inspectionResult.testCaseName;
+                    iOSEnergyDevice = inspectionResult.deviceIdentifier;
 
                     iosEnergyMetrics.push(result);
                 }
@@ -357,11 +365,12 @@ export default class PerfTestDashboard extends React.Component {
 
         var isIosMemoryInfoEnabled = iosMemoryInfo && iosMemoryInfo.performanceInspectionResults && iosMemoryInfo.performanceInspectionResults.length > 0
         var isIosMemoryInfoEmpty = true;
+        var iOSMemoryDevice = undefined;
 
         if (iosMemoryInfo && iosMemoryInfo.performanceInspectionResults && iosMemoryInfo.performanceInspectionResults.length > 0) {
             let startTime = iosMemoryInfo.performanceInspectionResults[0].timestamp;
+            iOSMemoryDevice = iosMemoryInfo.performanceInspectionResults[0].inspection.deviceIdentifier;
             iosMemoryInfo.performanceInspectionResults.forEach((inspectionResult) => {
-
                 if (inspectionResult && inspectionResult.parsedData) {
                     var result = { ...inspectionResult.parsedData };
                     let parsedData = { ...inspectionResult.parsedData };
@@ -429,7 +438,8 @@ export default class PerfTestDashboard extends React.Component {
 
             return <div> {!isHistoryEmpty && <div>
                 <h3> {perfTitleMap[historyMetrics[0].parserType].title} history report </h3>
-                <h4> {"App: " + historyMetrics[0].appId} </h4>
+                <h5> {"App: " + historyMetrics[0].appId} </h5>
+                <h5> {"Device: " + historyMetrics[0].deviceId} </h5>
                 <Select
                     defaultValue={options}
                     isMulti
@@ -462,9 +472,13 @@ export default class PerfTestDashboard extends React.Component {
         }
 
         return <div id='perf_dashboard'>
+            <div style={{ backgroundColor: '#2F5496', color: 'white', padding: '10px', fontSize: 'medium', fontWeight: 'bold', marginBottom: '20px' }}>
+                Performance Test Results
+            </div>
             {isAndroidBatteryInfoEnabled &&
                 <div>
                     <h3> Android Battery report</h3>
+                    {androidBatteryDevice && <h5>{"Device: " + androidBatteryDevice}</h5>}
                     {this.state.androidBatteryAppsOptions.length > 0 && <div style={{ marginBottom: '10px' }}>
                         <Select
                             defaultValue={this.state.androidBatteryAppsOptions[0]}
@@ -488,6 +502,7 @@ export default class PerfTestDashboard extends React.Component {
             {isAndroidMemoryInfoEnabled &&
                 <div>
                     <h3> Android Memory report</h3>
+                    {androidMemoryDevice && <h5>{"Device: " + androidMemoryDevice}</h5>}
                     {this.state.androidMemoryAppsOptions.length > 0 && <div style={{ marginBottom: '10px' }}>
                         <Select
                             defaultValue={this.state.androidMemoryAppsOptions[0]}
@@ -511,6 +526,7 @@ export default class PerfTestDashboard extends React.Component {
             {isWindowsMemoryInfoEnabled &&
                 <div>
                     <h3> Windows Memory report</h3>
+                    {windowsMemoryDevice && <h5>{"Device: " + windowsMemoryDevice}</h5>}
                     {this.state.windowsMemoryAppsOptions.length > 0 && <div style={{ marginBottom: '10px' }}>
                         <Select
                             defaultValue={this.state.windowsMemoryAppsOptions[0]}
@@ -533,6 +549,7 @@ export default class PerfTestDashboard extends React.Component {
             {isIosEnergyEnabled &&
                 <div>
                     <h3> iOS Energy report</h3>
+                    {iOSEnergyDevice && <h5>{"Device: " + iOSEnergyDevice}</h5>}
                     {this.state.iosEnergyAppsOptions.length > 0 && <div style={{ marginBottom: '10px' }}>
                         <Select
                             defaultValue={this.state.iosEnergyAppsOptions[0]}
@@ -554,6 +571,7 @@ export default class PerfTestDashboard extends React.Component {
             {isIosMemoryInfoEnabled &&
                 <div>
                     <h3> iOS Memory report</h3>
+                    {iOSMemoryDevice && <h5>{"Device: " + iOSMemoryDevice}</h5>}
                     {this.state.iosMemoryAppsOptions.length > 0 && <div style={{ marginBottom: '10px' }}>
                         <Select
                             defaultValue={this.state.iosMemoryAppsOptions[0]}
@@ -641,6 +659,7 @@ export default class PerfTestDashboard extends React.Component {
                 { key: "parserType", value: perfResult.parserType, "op": "equal" },
                 { key: "testSuite", value: this.state.testTask.testSuite, "op": "equal" },
                 { key: "runningType", value: this.state.testTask.runningType, "op": "equal" },
+                { key: "deviceId", value: inspection.deviceIdentifier, "op": "equal" },
             ];
             axios.post("api/test/performance/history", postBody).then(res => {
                 let newPerfHistoryList = [...this.state.perfHistoryList];

--- a/react/src/component/TestReportView.jsx
+++ b/react/src/component/TestReportView.jsx
@@ -513,16 +513,6 @@ export default class TestReportView extends BaseView {
             <div id='test_report_content_3>'>
                 {perfResults.length > 0 ? <div>
                     <table className='table table-borderless'>
-                        <thead className="thead-info">
-                            <tr className="table-info">
-                                <th colSpan={perfResults.length + ''}
-                                    style={{ backgroundColor: '#2F5496', color: 'white' }}>
-                                    Performance Test Results:
-                                </th>
-                            </tr>
-                        </thead>
-                    </table>
-                    <table className='table table-borderless'>
                         <tbody>
                             {suggestions.length > 0
                                 ? <div>


### PR DESCRIPTION
<!-- Please provide brief information about the PR, what it contains & its purpose, new behaviors after the change. And let us know here if you need any help: https://github.com/microsoft/HydraLab/issues/new -->

**Linked GitHub issue ID**: #  

## Pull Request Checklist
<!-- Put an x in the boxes that apply. This is simply a reminder of what we are going to look for before merging your code. -->

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Code compiles correctly with all tests are passed.
- [ ] I've read the [contributing guide](https://github.com/microsoft/HydraLab/blob/main/CONTRIBUTING.md#making-changes-to-the-code) and followed the recommended practices.
- [ ] [Wikis](https://github.com/microsoft/HydraLab/wiki) or [README](https://github.com/microsoft/HydraLab/blob/main/README.md) have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
*If this introduces a breaking change for Hydra Lab users, please describe the impact and migration path.*
- [ ] Yes
- [x] No

## Pull Request Description

**A few words to explain your changes**:  
- Add device info to the Perf dashboard
- Fix the bug of display confusion when more than two runs in a test task.

### How you tested it
*Please make sure the change is tested, you can test it by adding UTs, do local test and share the screenshots, etc.*


Please check the type of change your PR introduces:
- [x] Bugfix
- [x] Feature
- [ ] Technical design
- [ ] Build related changes
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Code style update (formatting, renaming) or Documentation content changes
- [ ] Other (please describe): 

### Feature UI screenshots or Technical design diagrams
*If this is a relatively large or complex change, kick it off by drawing the tech design with PlantUML and explaining why you chose the solution you did and what alternatives you considered, etc...*
![image](https://github.com/microsoft/HydraLab/assets/30514480/d5ca5c25-5fff-4478-82e8-44c0fe8c6908)

