### PR TITLE
Fix error handling logic of changeADBSocketHostAddr

### DIFF
--- a/common/src/main/java/com/microsoft/hydralab/common/util/ADBOperateUtil.java
+++ b/common/src/main/java/com/microsoft/hydralab/common/util/ADBOperateUtil.java
@@ -37,7 +37,6 @@ import java.util.concurrent.TimeUnit;
 
 @Service
 public class ADBOperateUtil {
-    private static final int ADB_WAIT_TIMEOUT_SECONDS = 120;
     private final Logger instanceLogger = LoggerFactory.getLogger(ADBOperateUtil.class);
     Runtime runtime = Runtime.getRuntime();
     private String mAndroidHome;
@@ -51,8 +50,11 @@ public class ADBOperateUtil {
 
         AndroidDebugBridge.initIfNeeded(false);
         if (!Objects.equals(adbServerHost, DdmPreferences.DEFAULT_ADBHOST_VALUE)) {
-            changeADBSocketHostAddr(adbServerHost);
-            instanceLogger.info("ADB server hostname is changed to {}", adbServerHost);
+            if (changeADBSocketHostAddr(adbServerHost)) {
+                instanceLogger.info("ADB server hostname is changed to {}", adbServerHost);
+            } else {
+                instanceLogger.warn("Failed to change ADB server hostname to {}", adbServerHost);
+            }
         }
         AndroidDebugBridge.addDeviceChangeListener(mListener);
 
@@ -82,15 +84,19 @@ public class ADBOperateUtil {
      *
      * @param adbServerHost adb server hostname, we need to change this to make it work inside a docker container. E.g. host.docker.internal or vm.docker.internal.
      */
-    private void changeADBSocketHostAddr(String adbServerHost) {
+    private boolean changeADBSocketHostAddr(String adbServerHost) {
         int port = AndroidDebugBridge.getSocketAddress().getPort();
         try {
             Field sSocketAddrField = AndroidDebugBridge.class.getDeclaredField("sSocketAddr");
             sSocketAddrField.setAccessible(true);
             sSocketAddrField.set(null, new InetSocketAddress(InetAddress.getByName(adbServerHost), port));
-        } catch (NoSuchFieldException | UnknownHostException | IllegalAccessException e) {
+            return true;
+        } catch (NoSuchFieldException | IllegalAccessException e) {
             instanceLogger.error("Error when changing the value of AndroidDebugBridge sSocketAddr", e);
+        } catch (UnknownHostException e) {
+            instanceLogger.error("Error when getting the InetAddress of " + adbServerHost, e);
         }
+        return false;
     }
 
     public RawImage getScreenshot(DeviceInfo deviceInfo, Logger logger) throws Exception {
@@ -143,7 +149,7 @@ public class ADBOperateUtil {
         }
     }
 
-    public void executeShellCommandOnDevice(DeviceInfo deviceInfo, String command, IShellOutputReceiver receiver, int testTimeOutSec,int responseTimeout) throws ShellCommandUnresponsiveException, AdbCommandRejectedException, IOException, TimeoutException {
+    public void executeShellCommandOnDevice(DeviceInfo deviceInfo, String command, IShellOutputReceiver receiver, int testTimeOutSec, int responseTimeout) throws ShellCommandUnresponsiveException, AdbCommandRejectedException, IOException, TimeoutException {
         IDevice device = getDeviceByInfo(deviceInfo);
         Assert.notNull(device, "Not such device is available " + deviceInfo.getSerialNum());
         device.executeShellCommand(command, receiver, testTimeOutSec, responseTimeout, TimeUnit.SECONDS);
@@ -231,7 +237,7 @@ public class ADBOperateUtil {
     public boolean uninstallApp(DeviceInfo deviceInfo, String packageName, Logger logger) {
         IDevice deviceByInfo = getDeviceByInfo(deviceInfo);
         Assert.notNull(deviceByInfo, "No such device: " + deviceInfo);
-        String msg = null;
+        String msg;
         try {
             msg = deviceByInfo.uninstallPackage(packageName);
         } catch (InstallException e) {


### PR DESCRIPTION
<!-- Please provide brief information about the PR, what it contains & its purpose, new behaviors after the change. And let us know here if you need any help: https://github.com/microsoft/HydraLab/issues/new -->

**Linked GitHub issue ID**: #  

## Pull Request Checklist
<!-- Put an x in the boxes that apply. This is simply a reminder of what we are going to look for before merging your code. -->

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Code compiles correctly with all tests are passed.
- [x] I've read the [contributing guide](https://github.com/microsoft/HydraLab/blob/main/CONTRIBUTING.md#making-changes-to-the-code) and followed the recommended practices.
- [ ] [Wikis](https://github.com/microsoft/HydraLab/wiki) or [README](https://github.com/microsoft/HydraLab/blob/main/README.md) have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
*If this introduces a breaking change for Hydra Lab users, please describe the impact and migration path.*

- [ ] Yes
- [x] No

## Pull Request Description

**A few words to explain your changes**:  Fix a error reported by coworkers

```
va:290)[WebSocketConnectReadThread-17] - Metric of agent running test task number has been registered.

2023-06-08 23:55:38,466 ERROR (c.m.h.c.u.ADBOperateUtil - ADBOperateUtil.java:79)[WebSocketConnectReadThread-17] - Error when changing the value of AndroidDebugBridge sSocketAddr

java.net.UnknownHostException: host.docker.internal: Name or service not known

at java.base/java.net.Inet4AddressImpl.lookupAllHostAddr(Native Method)

at java.base/java.net.InetAddress$PlatformNameService.lookupAllHostAddr(InetAddress.java:929)

at java.base/java.net.InetAddress.getAddressesFromNameService(InetAddress.java:1529)

at java.base/java.net.InetAddress$NameServiceAddresses.get(InetAddress.java:848)

at java.base/java.net.InetAddress.getAllByName0(InetAddress.java:1519)

at java.base/java.net.InetAddress.getAllByName(InetAddress.java:1378)

at java.base/java.net.InetAddress.getAllByName(InetAddress.java:1306)

at java.base/java.net.InetAddress.getByName(InetAddress.java:1256)

at com.microsoft.hydralab.common.util.ADBOperateUtil.changeADBSocketHostAddr(ADBOperateUtil.java:77)

at com.microsoft.hydralab.common.util.ADBOperateUtil.init(ADBOperateUtil.java:41)

at com.microsoft.hydralab.common.management.device.impl.AndroidTestDeviceManager.init(AndroidTestDeviceManager.java:135)

at com.microsoft.hydralab.agent.service.DeviceControlService.deviceManagerInit(DeviceControlService.java:177)

at com.microsoft.hydralab.agent.service.AgentWebSocketClientService.onMessage(AgentWebSocketClientService.java:97)

at com.microsoft.hydralab.agent.socket.AgentWebSocketClient.onMessage(AgentWebSocketClient.java:47)

at org.java_websocket.client.WebSocketClient.onWebsocketMessage(WebSocketClient.java:641)

at org.java_websocket.drafts.Draft_6455.processFrameBinary(Draft_6455.java:936)

at org.java_websocket.drafts.Draft_6455.processFrame(Draft_6455.java:889)

at org.java_websocket.WebSocketImpl.decodeFrames(WebSocketImpl.java:401)

at org.java_websocket.WebSocketImpl.decode(WebSocketImpl.java:233)

at org.java_websocket.client.WebSocketClient.run(WebSocketClient.java:516)

at java.base/java.lang.Thread.run(Thread.java:829)

2023-06-08 23:55:38,466 INFO (c.m.h.c.u.ADBOperateUtil - ADBOperateUtil.java:42)[WebSocketConnectReadThread-17] - ADB server hostname is changed to host.docker.internal

11:55:38 E/adb: * daemon not running; starting now at tcp:5037

11:55:38 E/adb: * daemon started successfully
```

### How you tested it
*Please make sure the change is tested, you can test it by adding UTs, do local test and share the screenshots, etc.*


Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Technical design
- [ ] Build related changes
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Code style update (formatting, renaming) or Documentation content changes
- [ ] Other (please describe): 

### Feature UI screenshots or Technical design diagrams
*If this is a relatively large or complex change, kick it off by drawing the tech design with PlantUML and explaining why you chose the solution you did and what alternatives you considered, etc...*
