### PR TITLE
Fix ADBScreenRecorder blocking issue in docker images

### DIFF
--- a/common/src/main/java/com/microsoft/hydralab/common/screen/FFmpegConcatUtil.java
+++ b/common/src/main/java/com/microsoft/hydralab/common/screen/FFmpegConcatUtil.java
@@ -19,9 +19,11 @@ public class FFmpegConcatUtil {
     static final String fileName = Const.ScreenRecoderConfig.DEFAULT_FILE_NAME;
     public static File concatVideos(List<File> videos, File outputDir, Logger logger) {
         if (videos.isEmpty()) {
+            logger.error("No video file exists.");
             return null;
         }
         if (videos.size() == 1) {
+            logger.info("Single video file exists, directly return.");
             File file = videos.get(0);
             Assert.isTrue(file.renameTo(new File(file.getParentFile(), fileName)), "rename fail");
             return file;


### PR DESCRIPTION
<!-- Please provide brief information about the PR, what it contains & its purpose, new behaviors after the change. And let us know here if you need any help: https://github.com/microsoft/HydraLab/issues/new -->

**Linked GitHub issue ID**: #  

## Pull Request Checklist
<!-- Put an x in the boxes that apply. This is simply a reminder of what we are going to look for before merging your code. -->

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Code compiles correctly with all tests are passed.
- [ ] I've read the [contributing guide](https://github.com/microsoft/HydraLab/blob/main/CONTRIBUTING.md#making-changes-to-the-code) and followed the recommended practices.
- [ ] [Wikis](https://github.com/microsoft/HydraLab/wiki) or [README](https://github.com/microsoft/HydraLab/blob/main/README.md) have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
*If this introduces a breaking change for Hydra Lab users, please describe the impact and migration path.*

- [ ] Yes
- [X] No

## Pull Request Description

**A few words to explain your changes**:  
- ADBScreenRecorder finishRecording waits less time (120s -> 30s);
- ADBScreenRecorder modifies process stream receiving logic to avoid blocking;
- Added some logs;

### How you tested it
*Please make sure the change is tested, you can test it by adding UTs, do local test and share the screenshots, etc.*


Please check the type of change your PR introduces:
- [X] Bugfix
- [ ] Feature
- [ ] Technical design
- [ ] Build related changes
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Code style update (formatting, renaming) or Documentation content changes
- [ ] Other (please describe): 

### Feature UI screenshots or Technical design diagrams
*If this is a relatively large or complex change, kick it off by drawing the tech design with PlantUML and explaining why you chose the solution you did and what alternatives you considered, etc...*
