### PR TITLE
Add disabling recording option for a test run to avoid OOM for tests with a long test time

### DIFF
--- a/agent/src/main/java/com/microsoft/hydralab/agent/runner/appium/AppiumListener.java
+++ b/agent/src/main/java/com/microsoft/hydralab/agent/runner/appium/AppiumListener.java
@@ -7,6 +7,7 @@ import com.microsoft.hydralab.agent.runner.TestRunDeviceOrchestrator;
 import com.microsoft.hydralab.common.entity.common.AndroidTestUnit;
 import com.microsoft.hydralab.common.entity.common.TestRun;
 import com.microsoft.hydralab.common.entity.common.TestRunDevice;
+import com.microsoft.hydralab.common.entity.common.TestTask;
 import com.microsoft.hydralab.common.management.AgentManagementService;
 import com.microsoft.hydralab.performance.PerformanceTestListener;
 import org.junit.runner.Description;
@@ -21,6 +22,7 @@ import java.util.Locale;
 public class AppiumListener extends RunListener {
     private final TestRunDevice testRunDevice;
     private final TestRun testRun;
+    private final TestTask testTask;
     private final Logger logger;
     private final String pkgName;
     AgentManagementService agentManagementService;
@@ -33,13 +35,14 @@ public class AppiumListener extends RunListener {
     private TestRunDeviceOrchestrator testRunDeviceOrchestrator;
 
     public AppiumListener(AgentManagementService agentManagementService, TestRunDevice testRunDevice, TestRun testRun,
-                          String pkgName, TestRunDeviceOrchestrator testRunDeviceOrchestrator,
+                          TestTask testTask, TestRunDeviceOrchestrator testRunDeviceOrchestrator,
                           PerformanceTestListener performanceTestListener, Logger logger) {
         this.agentManagementService = agentManagementService;
         this.testRunDevice = testRunDevice;
         this.testRun = testRun;
         this.logger = logger;
-        this.pkgName = pkgName;
+        this.testTask = testTask;
+        this.pkgName = testTask.getPkgName();
         this.performanceTestListener = performanceTestListener;
         this.testRunDeviceOrchestrator = testRunDeviceOrchestrator;
     }
@@ -60,7 +63,9 @@ public class AppiumListener extends RunListener {
 
     public void startRecording(int maxTime) {
         logger.info("Start record screen");
-        testRunDeviceOrchestrator.startScreenRecorder(testRunDevice, testRun.getResultFolder(), maxTime <= 0 ? 30 * 60 : maxTime, logger);
+        if (!testTask.isDisableRecording()) {
+            testRunDeviceOrchestrator.startScreenRecorder(testRunDevice, testRun.getResultFolder(), maxTime <= 0 ? 30 * 60 : maxTime, logger);
+        }
         logger.info("Start gif frames collection");
         testRunDeviceOrchestrator.startGifEncoder(testRunDevice, testRun.getResultFolder(), pkgName + ".gif");
         logger.info("Start logcat collection");
@@ -202,7 +207,9 @@ public class AppiumListener extends RunListener {
             testRun.onTestEnded();
             testRunDeviceOrchestrator.setRunningTestName(testRunDevice, null);
             testRunDeviceOrchestrator.stopGitEncoder(testRunDevice, agentManagementService.getScreenshotDir(), logger);
-            testRunDeviceOrchestrator.stopScreenRecorder(testRunDevice, testRun.getResultFolder(), logger);
+            if (!testTask.isDisableRecording()) {
+                testRunDeviceOrchestrator.stopScreenRecorder(testRunDevice, testRun.getResultFolder(), logger);
+            }
             testRunDeviceOrchestrator.stopLogCollector(testRunDevice);
             alreadyEnd = true;
         }

--- a/agent/src/main/java/com/microsoft/hydralab/agent/runner/appium/AppiumRunner.java
+++ b/agent/src/main/java/com/microsoft/hydralab/agent/runner/appium/AppiumRunner.java
@@ -100,7 +100,7 @@ public class AppiumRunner extends TestRunner {
         if (TestTask.TestFrameworkType.JUNIT5.equals(testTask.getFrameworkType())) {
             reportLogger.info("Start init listener");
             Junit5Listener junit5Listener =
-                    new Junit5Listener(agentManagementService, testRunDevice, testRun, testTask.getPkgName(),
+                    new Junit5Listener(agentManagementService, testRunDevice, testRun, testTask,
                             testRunDeviceOrchestrator, performanceTestManagementService, reportLogger);
 
             /** run the test */
@@ -114,7 +114,7 @@ public class AppiumRunner extends TestRunner {
             /** xml report: parse listener */
             reportLogger.info("Start init listener");
             AppiumListener listener =
-                    new AppiumListener(agentManagementService, testRunDevice, testRun, testTask.getPkgName(),
+                    new AppiumListener(agentManagementService, testRunDevice, testRun, testTask,
                             testRunDeviceOrchestrator, performanceTestManagementService, reportLogger);
 
             /** run the test */

--- a/agent/src/main/java/com/microsoft/hydralab/agent/runner/espresso/EspressoTestInfoProcessorListener.java
+++ b/agent/src/main/java/com/microsoft/hydralab/agent/runner/espresso/EspressoTestInfoProcessorListener.java
@@ -69,7 +69,9 @@ public class EspressoTestInfoProcessorListener extends XmlTestRunListener {
         testRunDeviceOrchestrator.startLogCollector(testRunDevice, pkgName, testRun, logger);
         testRun.setLogcatPath(agentManagementService.getTestBaseRelPathInUrl(new File(testRunDevice.getLogPath())));
         logger.info("Start record screen");
-        testRunDeviceOrchestrator.startScreenRecorder(testRunDevice, testRun.getResultFolder(), maxTime <= 0 ? 30 * 60 : maxTime, logger);
+        if (!testTask.isDisableRecording()) {
+            testRunDeviceOrchestrator.startScreenRecorder(testRunDevice, testRun.getResultFolder(), maxTime <= 0 ? 30 * 60 : maxTime, logger);
+        }
         recordingStartTimeMillis = System.currentTimeMillis();
         final String initializing = "Initializing";
         testRunDeviceOrchestrator.setRunningTestName(testRunDevice, initializing);
@@ -241,7 +243,9 @@ public class EspressoTestInfoProcessorListener extends XmlTestRunListener {
             testRunDeviceOrchestrator.stopNetworkMonitor(testRunDevice, logger);
         }
         testRunDeviceOrchestrator.stopGitEncoder(testRunDevice, agentManagementService.getScreenshotDir(), logger);
-        testRunDeviceOrchestrator.stopScreenRecorder(testRunDevice, testRun.getResultFolder(), logger);
+        if (!testTask.isDisableRecording()) {
+            testRunDeviceOrchestrator.stopScreenRecorder(testRunDevice, testRun.getResultFolder(), logger);
+        }
         testRunDeviceOrchestrator.stopLogCollector(testRunDevice);
     }
 }

--- a/agent/src/main/java/com/microsoft/hydralab/agent/runner/monkey/AdbMonkeyRunner.java
+++ b/agent/src/main/java/com/microsoft/hydralab/agent/runner/monkey/AdbMonkeyRunner.java
@@ -59,7 +59,7 @@ public class AdbMonkeyRunner extends TestRunner {
         logger = testRun.getLogger();
 
         pkgName = testTask.getPkgName();
-        startTools(testRun, testTask.getTimeOutSecond(), logger);
+        startTools(testTask, testRun, testTask.getTimeOutSecond(), logger);
 
         /** run the test */
         logger.info("Start " + TEST_RUN_NAME);
@@ -83,7 +83,7 @@ public class AdbMonkeyRunner extends TestRunner {
             }
         }
         performanceTestManagementService.testRunFinished();
-        testRunEnded(testRunDevice, testRun);
+        testRunEnded(testTask, testRunDevice, testRun);
 
         /** set paths */
         String absoluteReportPath = testRun.getResultFolder().getAbsolutePath();
@@ -95,9 +95,11 @@ public class AdbMonkeyRunner extends TestRunner {
 
     }
 
-    public void startTools(TestRun testRun, int maxTime, Logger logger) {
+    public void startTools(TestTask testTask, TestRun testRun, int maxTime, Logger logger) {
         /** start Record **/
-        testRunDeviceOrchestrator.startScreenRecorder(testRunDevice, testRun.getResultFolder(), maxTime, logger);
+        if (!testTask.isDisableRecording()) {
+            testRunDeviceOrchestrator.startScreenRecorder(testRunDevice, testRun.getResultFolder(), maxTime, logger);
+        }
         logger.info("Start record screen");
         recordingStartTimeMillis = System.currentTimeMillis();
         final String initializing = "Initializing";
@@ -178,12 +180,14 @@ public class AdbMonkeyRunner extends TestRunner {
         return checkTime;
     }
 
-    public void testRunEnded(TestRunDevice testRunDevice, TestRun testRun) {
+    public void testRunEnded(TestTask testTask, TestRunDevice testRunDevice, TestRun testRun) {
         testRun.addNewTimeTag("testRunEnded", System.currentTimeMillis() - recordingStartTimeMillis);
         testRun.onTestEnded();
         testRunDeviceOrchestrator.setRunningTestName(testRunDevice, null);
         testRunDeviceOrchestrator.stopGitEncoder(testRunDevice, agentManagementService.getScreenshotDir(), logger);
-        testRunDeviceOrchestrator.stopScreenRecorder(testRunDevice, testRun.getResultFolder(), logger);
+        if (!testTask.isDisableRecording()) {
+            testRunDeviceOrchestrator.stopScreenRecorder(testRunDevice, testRun.getResultFolder(), logger);
+        }
         testRunDeviceOrchestrator.stopLogCollector(testRunDevice);
     }
 }

--- a/agent/src/main/java/com/microsoft/hydralab/agent/runner/monkey/AppiumMonkeyRunner.java
+++ b/agent/src/main/java/com/microsoft/hydralab/agent/runner/monkey/AppiumMonkeyRunner.java
@@ -44,7 +44,9 @@ public class AppiumMonkeyRunner extends AppiumRunner {
 
         long recordingStartTimeMillis = System.currentTimeMillis();
 
-        testRunDeviceOrchestrator.startScreenRecorder(testRunDevice, deviceTestResultFolder, testTask.getTimeOutSecond(), logger);
+        if (!testTask.isDisableRecording()) {
+            testRunDeviceOrchestrator.startScreenRecorder(testRunDevice, deviceTestResultFolder, testTask.getTimeOutSecond(), logger);
+        }
         testRunDeviceOrchestrator.startLogCollector(testRunDevice, pkgName, testRun, logger);
         testRunDeviceOrchestrator.startGifEncoder(testRunDevice, testRun.getResultFolder(), pkgName + ".gif");
         testRun.setLogcatPath(agentManagementService.getTestBaseRelPathInUrl(new File(testRunDevice.getLogPath())));
@@ -76,7 +78,9 @@ public class AppiumMonkeyRunner extends AppiumRunner {
         runAppiumMonkey(testRunDevice, pkgName, testTask.getMaxStepCount(), logger);
 
         testRunDeviceOrchestrator.stopGitEncoder(testRunDevice, agentManagementService.getScreenshotDir(), logger);
-        testRunDeviceOrchestrator.stopScreenRecorder(testRunDevice, testRun.getResultFolder(), logger);
+        if (!testTask.isDisableRecording()) {
+            testRunDeviceOrchestrator.stopScreenRecorder(testRunDevice, testRun.getResultFolder(), logger);
+        }
         testRunDeviceOrchestrator.stopLogCollector(testRunDevice);
 
         // Success status

--- a/agent/src/main/java/com/microsoft/hydralab/agent/runner/t2c/T2CRunner.java
+++ b/agent/src/main/java/com/microsoft/hydralab/agent/runner/t2c/T2CRunner.java
@@ -67,7 +67,9 @@ public class T2CRunner extends AppiumRunner {
                                 TestRun testRun, File deviceTestResultFolder, Logger logger) {
         pkgName = testTask.getPkgName();
         // Test start
-        testRunDeviceOrchestrator.startScreenRecorder(testRunDevice, deviceTestResultFolder, testTask.getTimeOutSecond(), logger);
+        if (!testTask.isDisableRecording()) {
+            testRunDeviceOrchestrator.startScreenRecorder(testRunDevice, deviceTestResultFolder, testTask.getTimeOutSecond(), logger);
+        }
         long recordingStartTimeMillis = System.currentTimeMillis();
 
         testRunDeviceOrchestrator.startLogCollector(testRunDevice, pkgName, testRun, logger);
@@ -96,7 +98,9 @@ public class T2CRunner extends AppiumRunner {
         testRun.onTestEnded();
         testRunDeviceOrchestrator.setRunningTestName(testRunDevice, null);
         testRunDeviceOrchestrator.stopGitEncoder(testRunDevice, agentManagementService.getScreenshotDir(), logger);
-        testRunDeviceOrchestrator.stopScreenRecorder(testRunDevice, testRun.getResultFolder(), logger);
+        if (!testTask.isDisableRecording()) {
+            testRunDeviceOrchestrator.stopScreenRecorder(testRunDevice, testRun.getResultFolder(), logger);
+        }
         testRunDeviceOrchestrator.stopLogCollector(testRunDevice);
         return testRunDevice.getGifFile();
     }

--- a/agent/src/main/java/com/microsoft/hydralab/agent/runner/xctest/XCTestRunner.java
+++ b/agent/src/main/java/com/microsoft/hydralab/agent/runner/xctest/XCTestRunner.java
@@ -51,12 +51,14 @@ public class XCTestRunner extends TestRunner {
         List<String> result = runXctest(testRunDevice, logger, testTask, testRun);
         analysisXctestResult(result, testRun);
         FileUtil.deleteFile(new File(folderPath));
-        finishTest(testRunDevice, testRun);
+        finishTest(testRunDevice, testTask, testRun);
     }
 
     private void initializeTest(TestRunDevice testRunDevice, TestTask testTask, TestRun testRun) {
         logger = testRun.getLogger();
-        testRunDeviceOrchestrator.startScreenRecorder(testRunDevice, testRun.getResultFolder(), testTask.getTimeOutSecond(), logger);
+        if (!testTask.isDisableRecording()) {
+            testRunDeviceOrchestrator.startScreenRecorder(testRunDevice, testRun.getResultFolder(), testTask.getTimeOutSecond(), logger);
+        }
         testRunDeviceOrchestrator.startLogCollector(testRunDevice, testTask.getPkgName(), testRun, logger);
         testRunDeviceOrchestrator.startGifEncoder(testRunDevice, testRun.getResultFolder(), testTask.getPkgName() + ".gif");
         testRun.setLogcatPath(agentManagementService.getTestBaseRelPathInUrl(new File(testRunDevice.getLogPath())));
@@ -168,14 +170,16 @@ public class XCTestRunner extends TestRunner {
         testRun.setTotalCount(totalCases);
     }
 
-    private void finishTest(TestRunDevice testRunDevice, TestRun testRun) {
+    private void finishTest(TestRunDevice testRunDevice, TestTask testTask, TestRun testRun) {
         testRun.addNewTimeTag("testRunEnded", System.currentTimeMillis() - recordingStartTimeMillis);
         testRun.onTestEnded();
         String absoluteReportPath = testRun.getResultFolder().getAbsolutePath();
         testRun.setTestXmlReportPath(agentManagementService.getTestBaseRelPathInUrl(new File(absoluteReportPath)));
         testRun.setTestGifPath(agentManagementService.getTestBaseRelPathInUrl(testRunDevice.getGifFile()));
         testRunDeviceOrchestrator.stopGitEncoder(testRunDevice, agentManagementService.getScreenshotDir(), logger);
-        testRunDeviceOrchestrator.stopScreenRecorder(testRunDevice, testRun.getResultFolder(), logger);
+        if (!testTask.isDisableRecording()) {
+            testRunDeviceOrchestrator.stopScreenRecorder(testRunDevice, testRun.getResultFolder(), logger);
+        }
         testRunDeviceOrchestrator.stopLogCollector(testRunDevice);
     }
 }

--- a/common/src/main/java/com/microsoft/hydralab/common/entity/common/TestTask.java
+++ b/common/src/main/java/com/microsoft/hydralab/common/entity/common/TestTask.java
@@ -114,6 +114,8 @@ public class TestTask implements Serializable {
     private List<InspectionStrategy> inspectionStrategies;
     @Transient
     private String notifyUrl;
+    @Transient
+    private boolean disableRecording = false;
     private boolean enableNetworkMonitor;
     private String networkMonitorRule;
 

--- a/common/src/main/java/com/microsoft/hydralab/common/entity/common/TestTask.java
+++ b/common/src/main/java/com/microsoft/hydralab/common/entity/common/TestTask.java
@@ -169,6 +169,7 @@ public class TestTask implements Serializable {
         }
         testTask.setTestScope(testTaskSpec.testScope);
         testTask.setInspectionStrategies(testTaskSpec.inspectionStrategies);
+        testTask.setDisableRecording(testTaskSpec.disableRecording);
         testTask.setEnableNetworkMonitor(testTaskSpec.enableNetworkMonitor);
         testTask.setNetworkMonitorRule(testTaskSpec.networkMonitorRule);
 
@@ -206,6 +207,7 @@ public class TestTask implements Serializable {
         testTaskSpec.testRunnerName = testTask.getTestRunnerName();
         testTaskSpec.testScope = testTask.getTestScope();
         testTaskSpec.inspectionStrategies = testTask.getInspectionStrategies();
+        testTaskSpec.disableRecording = testTask.isDisableRecording();
         testTaskSpec.enableNetworkMonitor = testTask.isEnableNetworkMonitor();
         testTaskSpec.networkMonitorRule = testTask.getNetworkMonitorRule();
 

--- a/common/src/main/java/com/microsoft/hydralab/common/entity/common/TestTaskSpec.java
+++ b/common/src/main/java/com/microsoft/hydralab/common/entity/common/TestTaskSpec.java
@@ -49,6 +49,7 @@ public class TestTaskSpec {
     public String testSuiteClass;
     public Map<String, List<DeviceAction>> deviceActions;
     public List<InspectionStrategy> inspectionStrategies;
+    public boolean disableRecording = false;
     public boolean enableNetworkMonitor;
     public String networkMonitorRule;
 


### PR DESCRIPTION
<!-- Please provide brief information about the PR, what it contains & its purpose, new behaviors after the change. And let us know here if you need any help: https://github.com/microsoft/HydraLab/issues/new -->

**Linked GitHub issue ID**: #281 

## Pull Request Checklist
<!-- Put an x in the boxes that apply. This is simply a reminder of what we are going to look for before merging your code. -->

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Code compiles correctly with all tests are passed.
- [ ] I've read the [contributing guide](https://github.com/microsoft/HydraLab/blob/main/CONTRIBUTING.md#making-changes-to-the-code) and followed the recommended practices.
- [ ] [Wikis](https://github.com/microsoft/HydraLab/wiki) or [README](https://github.com/microsoft/HydraLab/blob/main/README.md) have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
*If this introduces a breaking change for Hydra Lab users, please describe the impact and migration path.*

- [ ] Yes
- [x] No

## Pull Request Description

**A few words to explain your changes**:  

### How you tested it
*Please make sure the change is tested, you can test it by adding UTs, do local test and share the screenshots, etc.*


Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Technical design
- [ ] Build related changes
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Code style update (formatting, renaming) or Documentation content changes
- [ ] Other (please describe): 

### Feature UI screenshots or Technical design diagrams
*If this is a relatively large or complex change, kick it off by drawing the tech design with PlantUML and explaining why you chose the solution you did and what alternatives you considered, etc...*
No recording video file generated when the `disableRecording` is `true`
![image](https://github.com/microsoft/HydraLab/assets/30514480/9eae25ef-564e-4695-9c49-9cb45e993930)
