### PR TITLE
Fix: some crashs are not thrown by ADB and only recorded in logcat, which not eventually result in test failure, and video cannot be stored correctly

### DIFF
--- a/agent/src/main/java/com/microsoft/hydralab/agent/runner/monkey/AdbMonkeyRunner.java
+++ b/agent/src/main/java/com/microsoft/hydralab/agent/runner/monkey/AdbMonkeyRunner.java
@@ -69,6 +69,8 @@ public class AdbMonkeyRunner extends TestRunner {
         performanceTestManagementService.testStarted(TEST_RUN_NAME);
         long checkTime = runMonkeyTestOnce(testRun, logger, testTask.getInstrumentationArgs(),
                 testTask.getMaxStepCount());
+
+        releaseResource(testTask, testRunDevice, testRun);
         if (checkTime > 0) {
             String crashStack = testRun.getCrashStack();
             if (crashStack != null && !"".equals(crashStack)) {
@@ -83,7 +85,7 @@ public class AdbMonkeyRunner extends TestRunner {
             }
         }
         performanceTestManagementService.testRunFinished();
-        testRunEnded(testTask, testRunDevice, testRun);
+        testRunEnded(testRun);
 
         /** set paths */
         String absoluteReportPath = testRun.getResultFolder().getAbsolutePath();
@@ -180,14 +182,17 @@ public class AdbMonkeyRunner extends TestRunner {
         return checkTime;
     }
 
-    public void testRunEnded(TestTask testTask, TestRunDevice testRunDevice, TestRun testRun) {
-        testRun.addNewTimeTag("testRunEnded", System.currentTimeMillis() - recordingStartTimeMillis);
-        testRun.onTestEnded();
+    public void releaseResource(TestTask testTask, TestRunDevice testRunDevice, TestRun testRun) {
         testRunDeviceOrchestrator.setRunningTestName(testRunDevice, null);
         testRunDeviceOrchestrator.stopGitEncoder(testRunDevice, agentManagementService.getScreenshotDir(), logger);
         if (!testTask.isDisableRecording()) {
             testRunDeviceOrchestrator.stopScreenRecorder(testRunDevice, testRun.getResultFolder(), logger);
         }
         testRunDeviceOrchestrator.stopLogCollector(testRunDevice);
+    }
+
+    public void testRunEnded(TestRun testRun) {
+        testRun.addNewTimeTag("testRunEnded", System.currentTimeMillis() - recordingStartTimeMillis);
+        testRun.onTestEnded();
     }
 }


### PR DESCRIPTION
<!-- Please provide brief information about the PR, what it contains & its purpose, new behaviors after the change. And let us know here if you need any help: https://github.com/microsoft/HydraLab/issues/new -->

## Description
Fix the following issue:
- Crash is not thrown by ADB and only recorded in logcat, which not eventually result in test failure, and video cannot be stored correctly.

<!-- A few words to explain your changes -->

### Linked GitHub issue ID: #  

## Pull Request Checklist
<!-- Put an x in the boxes that apply. This is simply a reminder of what we are going to look for before merging your code. -->

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Code compiles correctly with all tests are passed.
- [ ] I've read the [contributing guide](https://github.com/microsoft/HydraLab/blob/main/CONTRIBUTING.md#making-changes-to-the-code) and followed the recommended practices.
- [ ] [Wikis](https://github.com/microsoft/HydraLab/wiki) or [README](https://github.com/microsoft/HydraLab/blob/main/README.md) have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
*If this introduces a breaking change for Hydra Lab users, please describe the impact and migration path.*

- [ ] Yes
- [ ] No

## How you tested it
*Please make sure the change is tested, you can test it by adding UTs, do local test and share the screenshots, etc.*


Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Technical design
- [ ] Build related changes
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Code style update (formatting, renaming) or Documentation content changes
- [ ] Other (please describe): 

### Feature UI screenshots or Technical design diagrams
*If this is a relatively large or complex change, kick it off by drawing the tech design with PlantUML and explaining why you chose the solution you did and what alternatives you considered, etc...*
