### PR TITLE
Fix sleep between retries of startRecordingScreen

### DIFF
--- a/common/src/main/java/com/microsoft/hydralab/common/screen/IOSAppiumScreenRecorderForMac.java
+++ b/common/src/main/java/com/microsoft/hydralab/common/screen/IOSAppiumScreenRecorderForMac.java
@@ -27,7 +27,7 @@ public class IOSAppiumScreenRecorderForMac extends IOSAppiumScreenRecorder {
     public void startRecord(int maxTimeInSecond) {
         int timeout = maxTimeInSecond > 0 ? maxTimeInSecond : DEFAULT_TIMEOUT_IN_SECOND;
         try {
-            FlowUtil.retryAndSleepWhenFalse(3, 1000, () -> {
+            FlowUtil.retryAndSleepWhenFalse(3, 10, () -> {
                 iosDriver.startRecordingScreen(new IOSStartScreenRecordingOptions()
                         .enableForcedRestart()
                         .withFps(24)


### PR DESCRIPTION
<!-- Please provide brief information about the PR, what it contains & its purpose, new behaviors after the change. And let us know here if you need any help: https://github.com/microsoft/HydraLab/issues/new -->

## Description

A minor fix for the sleep time between `startRecordingScreen`. The `retryAndSleepWhenFalse` takes sleepSeconds param and it's set to 1000 second (probably a mistake). I changed the value to 10 second (align with the other usages of this method).

## Pull Request Checklist
<!-- Put an x in the boxes that apply. This is simply a reminder of what we are going to look for before merging your code. -->

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Code compiles correctly with all tests are passed.
- [x] I've read the [contributing guide](https://github.com/microsoft/HydraLab/blob/main/CONTRIBUTING.md#making-changes-to-the-code) and followed the recommended practices.
- [ ] [Wikis](https://github.com/microsoft/HydraLab/wiki) or [README](https://github.com/microsoft/HydraLab/blob/main/README.md) have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?

- [ ] Yes
- [x] No

## How you tested it
I encounter an issue running test on a mac machine. If appium failed to start the recording the `retryAndSleepWhenFalse` enter a very long sleep of 1000 seconds which block the test. Changing the value to 10 second (align with the other usages of this method) did fix the issue.


Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Technical design
- [ ] Build related changes
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Code style update (formatting, renaming) or Documentation content changes
- [ ] Other (please describe): 

