### PR TITLE
Bugfix: add null verify to adapt previous version agent & update front-page

### DIFF
--- a/center/src/main/java/com/microsoft/hydralab/center/service/DeviceAgentManagementService.java
+++ b/center/src/main/java/com/microsoft/hydralab/center/service/DeviceAgentManagementService.java
@@ -720,8 +720,8 @@ public class DeviceAgentManagementService {
 
         for (AgentDeviceGroup tempAgentDeviceGroup : agentDeviceGroups.values()) {
             AgentFunctionAvailability function = tempAgentDeviceGroup.getFunctionAvailabilities().stream()
-                    .filter(functionAvailability -> functionAvailability.getFunctionName().equals(testTaskSpec.runningType)).findFirst().get();
-            if (function.isEnabled()) {
+                    .filter(functionAvailability -> functionAvailability.getFunctionName().equals(testTaskSpec.runningType)).findFirst().orElse(null);
+            if (function != null && function.isEnabled()) {
                 List<EnvCapabilityRequirement> requirements = function.getEnvCapabilityRequirements();
                 boolean isMatch = true;
                 for (AnalysisTask.AnalysisConfig config : configs) {

--- a/react/src/component/TasksView.jsx
+++ b/react/src/component/TasksView.jsx
@@ -564,7 +564,7 @@ class TasksView extends BaseView {
                                 </td>
                                 <td style={{ fontSize: '0.875rem' }}>
                                     {task.overallSuccessRate}
-                                    {task.totalTestCount ? '(' +(task.totalTestCount - task.totalFailCount) + '/' + task.totalTestCount+ ')' : task.status}
+                                    {task.analysisConfigs ? task.status : '(' +(task.totalTestCount - task.totalFailCount) + '/' + task.totalTestCount+ ')'}
                                 </td>
                             </tr>
                         </tbody>


### PR DESCRIPTION
<!-- Please provide brief information about the PR, what it contains & its purpose, new behaviors after the change. And let us know here if you need any help: https://github.com/microsoft/HydraLab/issues/new -->

## Description
![image](https://github.com/microsoft/HydraLab/assets/26757995/940a5b87-b790-4213-988f-81a4ba5053b8)

<!-- A few words to explain your changes -->

### Linked GitHub issue ID: #  

## Pull Request Checklist
<!-- Put an x in the boxes that apply. This is simply a reminder of what we are going to look for before merging your code. -->

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Code compiles correctly with all tests are passed.
- [x] I've read the [contributing guide](https://github.com/microsoft/HydraLab/blob/main/CONTRIBUTING.md#making-changes-to-the-code) and followed the recommended practices.
- [ ] [Wikis](https://github.com/microsoft/HydraLab/wiki) or [README](https://github.com/microsoft/HydraLab/blob/main/README.md) have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
*If this introduces a breaking change for Hydra Lab users, please describe the impact and migration path.*

- [x] Yes
- [ ] No

## How you tested it
*Please make sure the change is tested, you can test it by adding UTs, do local test and share the screenshots, etc.*


Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Technical design
- [ ] Build related changes
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Code style update (formatting, renaming) or Documentation content changes
- [ ] Other (please describe): 

### Feature UI screenshots or Technical design diagrams
*If this is a relatively large or complex change, kick it off by drawing the tech design with PlantUML and explaining why you chose the solution you did and what alternatives you considered, etc...*
