### PR TITLE
User/ujsrivastava/block unblock device test spec

### DIFF
--- a/center/src/main/java/com/microsoft/hydralab/center/controller/TestTaskController.java
+++ b/center/src/main/java/com/microsoft/hydralab/center/controller/TestTaskController.java
@@ -89,7 +89,7 @@ public class TestTaskController {
             //if the queue is not empty, the task will be added to the queue directly
             if (testTaskService.isQueueEmpty()
                     || Task.RunnerType.APK_SCANNER.name().equals(testTaskSpec.runningType)
-                    || testTaskService.isDeviceFree(testTaskSpec.deviceIdentifier)) {
+                    || deviceAgentManagementService.isRunOnBlockedDevice(testTaskSpec) || testTaskService.isDeviceFree(testTaskSpec.deviceIdentifier)) {
                 result = deviceAgentManagementService.runTestTaskBySpec(testTaskSpec);
                 if (result.get(Const.Param.TEST_DEVICE_SN) == null) {
                     //if there is no alive device, the task will be added to the queue directly

--- a/center/src/main/java/com/microsoft/hydralab/center/controller/TestTaskController.java
+++ b/center/src/main/java/com/microsoft/hydralab/center/controller/TestTaskController.java
@@ -83,7 +83,7 @@ public class TestTaskController {
             testTaskSpec.testTaskId = UUID.randomUUID().toString();
 
             if (testTaskSpec.blockDevice && testTaskSpec.unblockDevice) {
-                throw new IllegalArgumentException("Cannot block and unblock device at the same time");
+                throw new IllegalArgumentException("Cannot block and unblock device in the same test task.");
             }
             if (testTaskSpec.unblockDevice && Strings.isNullOrEmpty(testTaskSpec.unblockDeviceSecretKey)) {
                 throw new IllegalArgumentException("Unblock secret key is required when unblocking a device.");

--- a/center/src/main/java/com/microsoft/hydralab/center/controller/TestTaskController.java
+++ b/center/src/main/java/com/microsoft/hydralab/center/controller/TestTaskController.java
@@ -5,6 +5,7 @@ package com.microsoft.hydralab.center.controller;
 
 import com.alibaba.fastjson.JSONArray;
 import com.alibaba.fastjson.JSONObject;
+import com.google.common.base.Strings;
 import com.microsoft.hydralab.center.service.DeviceAgentManagementService;
 import com.microsoft.hydralab.center.service.SysUserService;
 import com.microsoft.hydralab.center.service.TestDataService;
@@ -80,6 +81,18 @@ public class TestTaskController {
             testTaskSpec.teamId = testFileSet.getTeamId();
             testTaskSpec.teamName = testFileSet.getTeamName();
             testTaskSpec.testTaskId = UUID.randomUUID().toString();
+
+            if (testTaskSpec.blockDevice && testTaskSpec.unblockDevice) {
+                throw new IllegalArgumentException("Cannot block and unblock device at the same time");
+            }
+            if (testTaskSpec.unblockDevice && Strings.isNullOrEmpty(testTaskSpec.unblockDeviceSecretKey)) {
+                throw new IllegalArgumentException("Unblock secret key is required when unblocking a device.");
+            }
+
+            if (testTaskSpec.unblockDevice && testTaskSpec.deviceIdentifier.startsWith("G.")) {
+                throw new IllegalArgumentException("deviceIdentifier should not be a group when unblocking a device.");
+            }
+
             if (!sysUserService.checkUserAdmin(requestor)) {
                 if (!userTeamManagementService.checkRequestorTeamRelation(requestor, testTaskSpec.teamId)) {
                     return Result.error(HttpStatus.UNAUTHORIZED.value(), "Unauthorized, the TestFileSet doesn't belong to user's Teams");

--- a/center/src/main/java/com/microsoft/hydralab/center/service/DeviceAgentManagementService.java
+++ b/center/src/main/java/com/microsoft/hydralab/center/service/DeviceAgentManagementService.java
@@ -978,11 +978,6 @@ public class DeviceAgentManagementService {
     }
 
     private JSONObject runTestTaskByDevice(TestTaskSpec testTaskSpec) {
-        if (testTaskSpec.unblockDevice) {
-            unBlockDevice(testTaskSpec.deviceIdentifier, testTaskSpec.unblockDeviceSecretKey);
-            testTaskSpec.unblockedDeviceSerialNumber = testTaskSpec.deviceIdentifier;
-        }
-
         JSONObject result = new JSONObject();
 
         DeviceInfo device = deviceListMap.get(testTaskSpec.deviceIdentifier);
@@ -1003,6 +998,12 @@ public class DeviceAgentManagementService {
             return result;
         }
         updateDeviceStatus(device.getSerialNum(), DeviceInfo.TESTING, testTaskSpec.testTaskId);
+
+        if (testTaskSpec.unblockDevice) {
+            unBlockDevice(testTaskSpec.deviceIdentifier, testTaskSpec.unblockDeviceSecretKey);
+            testTaskSpec.unblockedDeviceSerialNumber = testTaskSpec.deviceIdentifier;
+        }
+        
         if (testTaskSpec.blockDevice) {
             blockDevice(testTaskSpec.deviceIdentifier, testTaskSpec.testTaskId);
             testTaskSpec.blockedDeviceSerialNumber = testTaskSpec.deviceIdentifier;

--- a/center/src/main/java/com/microsoft/hydralab/center/service/DeviceAgentManagementService.java
+++ b/center/src/main/java/com/microsoft/hydralab/center/service/DeviceAgentManagementService.java
@@ -1003,6 +1003,9 @@ public class DeviceAgentManagementService {
             return result;
         }
         updateDeviceStatus(device.getSerialNum(), DeviceInfo.TESTING, testTaskSpec.testTaskId);
+        if (testTaskSpec.blockDevice) {
+            blockDevice(testTaskSpec.deviceIdentifier, testTaskSpec.testTaskId);
+        }
         testTaskSpec.agentIds.add(device.getAgentId());
         sendMessageToSession(agentSessionInfoByAgentId.session, message);
         result.put(Const.Param.TEST_DEVICE_SN, testTaskSpec.deviceIdentifier);

--- a/center/src/main/java/com/microsoft/hydralab/center/service/DeviceAgentManagementService.java
+++ b/center/src/main/java/com/microsoft/hydralab/center/service/DeviceAgentManagementService.java
@@ -1003,7 +1003,7 @@ public class DeviceAgentManagementService {
             unBlockDevice(testTaskSpec.deviceIdentifier, testTaskSpec.unblockDeviceSecretKey);
             testTaskSpec.unblockedDeviceSerialNumber = testTaskSpec.deviceIdentifier;
         }
-        
+
         if (testTaskSpec.blockDevice) {
             blockDevice(testTaskSpec.deviceIdentifier, testTaskSpec.testTaskId);
             testTaskSpec.blockedDeviceSerialNumber = testTaskSpec.deviceIdentifier;

--- a/center/src/main/java/com/microsoft/hydralab/center/service/TestTaskService.java
+++ b/center/src/main/java/com/microsoft/hydralab/center/service/TestTaskService.java
@@ -66,8 +66,16 @@ public class TestTaskService {
                 relatedIdentifiers.addAll(deviceAgentManagementService.queryGroupByDevice(deviceIdentifier));
             }
         } else if (deviceIdentifier.startsWith(Const.DeviceGroup.GROUP_NAME_PREFIX)) {
+            if (deviceAgentManagementService.areAllDevicesBlocked(deviceIdentifier)) {
+                logger.warn("All Devices in the DeviceGroup " + deviceIdentifier + " are blocked currently.");
+                return false;
+            }
             relatedIdentifiers.addAll(deviceAgentManagementService.queryDeviceByGroup(deviceIdentifier));
         } else {
+            if (deviceAgentManagementService.isDeviceBlocked(deviceIdentifier)) {
+                logger.warn("Device " + deviceIdentifier + " is blocked currently.");
+                return false;
+            }
             relatedIdentifiers.addAll(deviceAgentManagementService.queryGroupByDevice(deviceIdentifier));
         }
         synchronized (taskQueue) {
@@ -92,6 +100,7 @@ public class TestTaskService {
             return;
         }
         isRunning.set(true);
+
         synchronized (taskQueue) {
             Iterator<TestTaskSpec> queueIterator = taskQueue.iterator();
             while (queueIterator.hasNext()) {

--- a/common/src/main/java/com/microsoft/hydralab/common/entity/common/BlockedDeviceInfo.java
+++ b/common/src/main/java/com/microsoft/hydralab/common/entity/common/BlockedDeviceInfo.java
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+package com.microsoft.hydralab.common.entity.common;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+import java.time.Instant;
+
+@Getter
+@Setter
+@ToString
+public class BlockedDeviceInfo {
+    public Instant blockedTime;
+    public String blockingTaskUUID;
+    public String blockedDeviceSerialNumber;
+}

--- a/common/src/main/java/com/microsoft/hydralab/common/entity/common/Task.java
+++ b/common/src/main/java/com/microsoft/hydralab/common/entity/common/Task.java
@@ -86,6 +86,13 @@ public class Task implements Serializable {
     private boolean disableRecording = false;
     @Column(columnDefinition = "boolean default false")
     private boolean isSucceed = false;
+    public String blockedDeviceSerialNumber;
+    public String unblockedDeviceSerialNumber;
+    public String unblockDeviceSecretKey;
+    @Transient
+    public boolean blockDevice = false;
+    @Transient
+    public boolean unblockDevice = false;
 
     @Transient
     private List<TestRun> deviceTestResults;
@@ -164,6 +171,16 @@ public class Task implements Serializable {
         testTaskSpec.disableRecording = isDisableRecording();
         testTaskSpec.retryTime = getRetryTime();
 
+        if (isBlockDevice()) {
+            testTaskSpec.blockDevice = true;
+            testTaskSpec.blockedDeviceSerialNumber = getBlockedDeviceSerialNumber();
+            testTaskSpec.unblockDeviceSecretKey = getUnblockDeviceSecretKey();
+        }
+        if (isUnblockDevice()) {
+            testTaskSpec.unblockDevice = true;
+            testTaskSpec.unblockedDeviceSerialNumber = getUnblockedDeviceSerialNumber();
+            testTaskSpec.unblockDeviceSecretKey = getUnblockDeviceSecretKey();
+        }
         return testTaskSpec;
     }
 
@@ -198,6 +215,18 @@ public class Task implements Serializable {
         setTeamName(testTaskSpec.teamName);
         setNotifyUrl(testTaskSpec.notifyUrl);
         setDisableRecording(testTaskSpec.disableRecording);
+
+        if (testTaskSpec.blockDevice) {
+            setBlockDevice(true);
+            setBlockedDeviceSerialNumber(testTaskSpec.blockedDeviceSerialNumber);
+            setUnblockDeviceSecretKey(testTaskSpec.unblockDeviceSecretKey);
+        }
+
+        if (testTaskSpec.unblockDevice) {
+            setUnblockDevice(true);
+            setUnblockedDeviceSerialNumber(testTaskSpec.unblockedDeviceSerialNumber);
+            setUnblockDeviceSecretKey(testTaskSpec.unblockDeviceSecretKey);
+        }
     }
 
     public Task() {

--- a/common/src/main/java/com/microsoft/hydralab/common/entity/common/TestTaskSpec.java
+++ b/common/src/main/java/com/microsoft/hydralab/common/entity/common/TestTaskSpec.java
@@ -57,6 +57,11 @@ public class TestTaskSpec {
     public boolean enableNetworkMonitor;
     public String networkMonitorRule;
     public boolean enableTestOrchestrator = false;
+    public boolean blockDevice = false;
+    public boolean unblockDevice = false;
+    public String blockedDeviceSerialNumber;
+    public String unblockedDeviceSerialNumber;
+    public String unblockDeviceSecretKey;
 
     public void updateWithDefaultValues() {
         determineScopeOfTestCase();

--- a/common/src/main/java/com/microsoft/hydralab/common/util/Const.java
+++ b/common/src/main/java/com/microsoft/hydralab/common/util/Const.java
@@ -3,6 +3,7 @@
 
 package com.microsoft.hydralab.common.util;
 
+import java.time.Duration;
 import java.util.List;
 
 public interface Const {
@@ -32,6 +33,7 @@ public interface Const {
         String SINGLE_TYPE = "SINGLE";
         String REST_TYPE = "REST";
         String ALL_TYPE = "ALL";
+        Duration BLOCKED_DEVICE_TIMEOUT = Duration.ofHours(4);
     }
 
     interface AgentConfig {

--- a/gradle_plugin/src/main/groovy/com/microsoft/hydralab/ClientUtilsPlugin.groovy
+++ b/gradle_plugin/src/main/groovy/com/microsoft/hydralab/ClientUtilsPlugin.groovy
@@ -173,6 +173,18 @@ class ClientUtilsPlugin implements Plugin<Project> {
                     // add quotes back as quotes in gradle plugins will be replaced by blanks
                     testConfig.analysisConfigsStr = project.analysisConfigsStr.replace("\\", "\"")
                 }
+                if (project.hasProperty('blockDevice')) {
+                    // block a device from a group of devices
+                    testConfig.blockDevice = project.blockDevice
+                }
+                if (project.hasProperty('unblockDevice')) {
+                   // unblock a device
+                    testConfig.unblockDevice = project.unblockDevice
+                }
+                if (project.hasProperty('unblockDeviceSecretKey')) {
+                    // secret key to unblock a device
+                    testConfig.unblockDeviceSecretKey = project.unblockDeviceSecretKey
+                }
 
                 requiredParamCheck(apiConfig, testConfig)
 
@@ -210,6 +222,9 @@ class ClientUtilsPlugin implements Plugin<Project> {
                 }
                 if (StringUtils.isBlank(testConfig.testSuiteName)) {
                     throw new IllegalArgumentException('Running type ' + testConfig.runningType + ' required param testSuiteName not provided!')
+                }
+                if (testConfig.unblockDevice && StringUtils.isBlank(testConfig.unblockDeviceSecretKey)) {
+                    throw new IllegalArgumentException('Running type ' + testConfig.runningType + ' required param unblockDeviceSecretKey not provided!')
                 }
                 break
             case "APPIUM":

--- a/gradle_plugin/src/main/groovy/com/microsoft/hydralab/ClientUtilsPlugin.groovy
+++ b/gradle_plugin/src/main/groovy/com/microsoft/hydralab/ClientUtilsPlugin.groovy
@@ -11,6 +11,7 @@ import com.microsoft.hydralab.utils.YamlParser
 import org.apache.commons.lang3.StringUtils
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.internal.impldep.com.sun.xml.bind.v2.runtime.reflect.opt.Const
 
 
 class ClientUtilsPlugin implements Plugin<Project> {
@@ -228,6 +229,9 @@ class ClientUtilsPlugin implements Plugin<Project> {
                 }
                 if (testConfig.blockDevice && testConfig.unblockDevice) {
                     throw new IllegalArgumentException('Running type ' + testConfig.runningType + ' param block and unblock device should not be true in the same test task!')
+                }
+                if(testConfig.unblockDevice && testConfig.deviceConfig.deviceIdentifier.startsWith("G.")) {
+                    throw new IllegalArgumentException('Running type ' + testConfig.runningType + ' param deviceIdentifier should not be a Group when unblockDevice is set to true!')
                 }
                 break
             case "APPIUM":

--- a/gradle_plugin/src/main/groovy/com/microsoft/hydralab/ClientUtilsPlugin.groovy
+++ b/gradle_plugin/src/main/groovy/com/microsoft/hydralab/ClientUtilsPlugin.groovy
@@ -226,6 +226,9 @@ class ClientUtilsPlugin implements Plugin<Project> {
                 if (testConfig.unblockDevice && StringUtils.isBlank(testConfig.unblockDeviceSecretKey)) {
                     throw new IllegalArgumentException('Running type ' + testConfig.runningType + ' required param unblockDeviceSecretKey not provided!')
                 }
+                if (testConfig.blockDevice && testConfig.unblockDevice) {
+                    throw new IllegalArgumentException('Running type ' + testConfig.runningType + ' param block and unblock device should not be true in the same test task!')
+                }
                 break
             case "APPIUM":
                 if (StringUtils.isBlank(testConfig.testAppPath)) {

--- a/gradle_plugin/src/main/groovy/com/microsoft/hydralab/config/TestConfig.java
+++ b/gradle_plugin/src/main/groovy/com/microsoft/hydralab/config/TestConfig.java
@@ -60,6 +60,9 @@ public class TestConfig {
     public boolean enableTestOrchestrator = false;
     public List<AnalysisConfig> analysisConfigs = new ArrayList<>();
     public String analysisConfigsStr = "";
+    public Boolean blockDevice = false;
+    public Boolean unblockDevice = false;
+    public String unblockDeviceSecretKey = "";
 
     public void constructField(HashMap<String, Object> map) {
         Object queueTimeOutSeconds = map.get("queueTimeOutSeconds");

--- a/gradle_plugin/src/main/groovy/com/microsoft/hydralab/entity/TestTask.java
+++ b/gradle_plugin/src/main/groovy/com/microsoft/hydralab/entity/TestTask.java
@@ -19,6 +19,9 @@ public class TestTask {
     public String testErrorMsg;
     public String message;
     public int retryTime;
+    public String blockedDeviceSerialNumber;
+    public String unblockedDeviceSerialNumber;
+    public String unblockDeviceSecretKey;
 
     @Override
     public String toString() {

--- a/gradle_plugin/src/main/groovy/com/microsoft/hydralab/utils/HydraLabAPIClient.java
+++ b/gradle_plugin/src/main/groovy/com/microsoft/hydralab/utils/HydraLabAPIClient.java
@@ -240,6 +240,9 @@ public class HydraLabAPIClient {
         jsonElement.addProperty("networkMonitorRule", testConfig.networkMonitorRule);
         jsonElement.addProperty("enableTestOrchestrator", testConfig.enableTestOrchestrator);
         jsonElement.addProperty("notifyUrl", testConfig.notifyUrl);
+        jsonElement.addProperty("blockDevice", testConfig.blockDevice);
+        jsonElement.addProperty("unblockDevice", testConfig.unblockDevice);
+        jsonElement.addProperty("unblockDeviceSecretKey", testConfig.unblockDeviceSecretKey);
 
         try {
             if (testConfig.neededPermissions.size() > 0) {

--- a/gradle_plugin/src/main/groovy/com/microsoft/hydralab/utils/HydraLabClientUtils.java
+++ b/gradle_plugin/src/main/groovy/com/microsoft/hydralab/utils/HydraLabClientUtils.java
@@ -227,7 +227,7 @@ public class HydraLabClientUtils {
         if (testConfig.blockDevice) {
             assertNotNull(runningTest.blockedDeviceSerialNumber, "blockedDeviceSerialNumber");
             printlnf("##vso[task.setvariable variable=BlockedDeviceSerialNumber;isOutput=true]%s", runningTest.blockedDeviceSerialNumber);
-            printlnf("##vso[task.setvariable variable=BlockingTaskUUID;isOutput=true]%s", runningTest.unblockDeviceSecretKey);
+            printlnf("##vso[task.setvariable variable=UnblockDeviceSecretKey;isOutput=true]%s", runningTest.unblockDeviceSecretKey);
         }
 
         if (testConfig.unblockDevice && testConfig.deviceConfig.deviceIdentifier.equals(runningTest.unblockedDeviceSerialNumber)) {

--- a/gradle_plugin/src/main/groovy/com/microsoft/hydralab/utils/HydraLabClientUtils.java
+++ b/gradle_plugin/src/main/groovy/com/microsoft/hydralab/utils/HydraLabClientUtils.java
@@ -224,6 +224,15 @@ public class HydraLabClientUtils {
 
         assertNotNull(runningTest, "runningTest");
         assertNotNull(runningTest.deviceTestResults, "runningTest.deviceTestResults");
+        if (testConfig.blockDevice) {
+            assertNotNull(runningTest.blockedDeviceSerialNumber, "blockedDeviceSerialNumber");
+            printlnf("##vso[task.setvariable variable=BlockedDeviceSerialNumber;isOutput=true]%s", runningTest.blockedDeviceSerialNumber);
+            printlnf("##vso[task.setvariable variable=BlockingTaskUUID;isOutput=true]%s", runningTest.unblockDeviceSecretKey);
+        }
+
+        if (testConfig.unblockDevice && testConfig.deviceConfig.deviceIdentifier.equals(runningTest.unblockedDeviceSerialNumber)) {
+            printlnf("##[section] Device % s, unblocked.", runningTest.unblockedDeviceSerialNumber);
+        }
 
         String testReportUrl = apiConfig.getTestReportUrl(runningTest.id);
 

--- a/gradle_plugin/src/test/java/com/microsoft/hydralab/ClientUtilsPluginTest.java
+++ b/gradle_plugin/src/test/java/com/microsoft/hydralab/ClientUtilsPluginTest.java
@@ -82,6 +82,8 @@ public class ClientUtilsPluginTest {
         testConfig.testSuiteName = "";
         testConfig.testPkgName = "";
         testConfig.testScope = "";
+        testConfig.unblockDevice = false;
+        testConfig.unblockDeviceSecretKey = "";
         apiConfig.host = "www.test.host";
         apiConfig.authToken = "thisisanauthtokenonlyfortest";
         deviceConfig.deviceIdentifier = "TESTDEVICESN001";
@@ -106,6 +108,12 @@ public class ClientUtilsPluginTest {
         clientUtilsPlugin.requiredParamCheck(apiConfig, testConfig);
 
         testConfig.testScope = ClientUtilsPlugin.TestScope.CLASS;
+        clientUtilsPlugin.requiredParamCheck(apiConfig, testConfig);
+
+        testConfig.unblockDevice = true;
+        typeSpecificParamCheck(apiConfig, testConfig, "unblockDeviceSecretKey");
+
+        testConfig.unblockDeviceSecretKey = "UNBLOCKDEVICESECRET001";
         clientUtilsPlugin.requiredParamCheck(apiConfig, testConfig);
     }
 

--- a/gradle_plugin/src/test/java/com/microsoft/hydralab/ClientUtilsPluginTest.java
+++ b/gradle_plugin/src/test/java/com/microsoft/hydralab/ClientUtilsPluginTest.java
@@ -83,6 +83,7 @@ public class ClientUtilsPluginTest {
         testConfig.testPkgName = "";
         testConfig.testScope = "";
         testConfig.unblockDevice = false;
+        testConfig.blockDevice = false;
         testConfig.unblockDeviceSecretKey = "";
         apiConfig.host = "www.test.host";
         apiConfig.authToken = "thisisanauthtokenonlyfortest";
@@ -114,6 +115,11 @@ public class ClientUtilsPluginTest {
         typeSpecificParamCheck(apiConfig, testConfig, "unblockDeviceSecretKey");
 
         testConfig.unblockDeviceSecretKey = "UNBLOCKDEVICESECRET001";
+        testConfig.blockDevice = true;
+        typeSpecificParamCheck(apiConfig, testConfig, "blockUnblockDevice");
+
+        testConfig.blockDevice = false;
+
         clientUtilsPlugin.requiredParamCheck(apiConfig, testConfig);
     }
 
@@ -259,6 +265,10 @@ public class ClientUtilsPluginTest {
         IllegalArgumentException thrown = Assertions.assertThrows(IllegalArgumentException.class, () -> {
             clientUtilsPlugin.requiredParamCheck(apiConfig, testConfig);
         }, "IllegalArgumentException was expected");
-        Assertions.assertEquals("Running type " + testConfig.runningType + " required param " + requiredParamName + " not provided!", thrown.getMessage());
+        if (requiredParamName.equals("blockUnblockDevice")) {
+            Assertions.assertEquals("Running type " + testConfig.runningType + " param block and unblock device should not be true in the same test task!", thrown.getMessage());
+        } else {
+            Assertions.assertEquals("Running type " + testConfig.runningType + " required param " + requiredParamName + " not provided!", thrown.getMessage());
+        }
     }
 }

--- a/gradle_plugin/src/test/java/com/microsoft/hydralab/ClientUtilsPluginTest.java
+++ b/gradle_plugin/src/test/java/com/microsoft/hydralab/ClientUtilsPluginTest.java
@@ -117,8 +117,12 @@ public class ClientUtilsPluginTest {
         testConfig.unblockDeviceSecretKey = "UNBLOCKDEVICESECRET001";
         testConfig.blockDevice = true;
         typeSpecificParamCheck(apiConfig, testConfig, "blockUnblockDevice");
-
         testConfig.blockDevice = false;
+
+        deviceConfig.deviceIdentifier = "G.GROUP001";
+        typeSpecificParamCheck(apiConfig, testConfig, "unblockDeviceGroup");
+
+        deviceConfig.deviceIdentifier = "TESTDEVICESN001";
 
         clientUtilsPlugin.requiredParamCheck(apiConfig, testConfig);
     }
@@ -267,7 +271,10 @@ public class ClientUtilsPluginTest {
         }, "IllegalArgumentException was expected");
         if (requiredParamName.equals("blockUnblockDevice")) {
             Assertions.assertEquals("Running type " + testConfig.runningType + " param block and unblock device should not be true in the same test task!", thrown.getMessage());
-        } else {
+        } else if(requiredParamName.equals("unblockDeviceGroup")) {
+            Assertions.assertEquals("Running type " + testConfig.runningType + " param deviceIdentifier should not be a Group when unblockDevice is set to true!", thrown.getMessage());
+        }
+        else {
             Assertions.assertEquals("Running type " + testConfig.runningType + " required param " + requiredParamName + " not provided!", thrown.getMessage());
         }
     }

--- a/gradle_plugin/src/test/java/com/microsoft/hydralab/ClientUtilsPluginTest.java
+++ b/gradle_plugin/src/test/java/com/microsoft/hydralab/ClientUtilsPluginTest.java
@@ -189,6 +189,8 @@ public class ClientUtilsPluginTest {
         testConfig.appPath = "src/test/resources/app.txt";
         testConfig.testAppPath = "src/test/resources/test_app.txt";
         testConfig.attachmentInfos = new ArrayList<>();
+        testConfig.blockDevice = true;
+        testConfig.unblockDevice = false;
 
         String returnId = "id123456";
         when(client.uploadApp(Mockito.any(HydraLabAPIConfig.class), Mockito.any(TestConfig.class), Mockito.anyString(), Mockito.anyString(),
@@ -225,6 +227,8 @@ public class ClientUtilsPluginTest {
         returnTestTask.totalTestCount = 5;
         returnTestTask.totalFailCount = 1;
         returnTestTask.reportImagePath = "./image_path/image";
+        returnTestTask.blockedDeviceSerialNumber = "TESTDEVICESN001";
+        returnTestTask.unblockDeviceSecretKey = "UNBLOCKDEVICESECRET001";
         when(client.getTestStatus(Mockito.any(HydraLabAPIConfig.class), Mockito.anyString()))
                 .thenReturn(returnTestTask);
 


### PR DESCRIPTION
<!-- Please provide brief information about the PR, what it contains & its purpose, new behaviors after the change. And let us know here if you need any help: https://github.com/microsoft/HydraLab/issues/new -->

## Description
This Pull Request adds two properties to the *requestHydraLabTest* test configuation for blocking and unblocking a device on which the test runs. 

<ins>**Blocking a device by a task**</ins>
<ins>**Input:**</ins>
A boolean property *blockDevice* needs to be provided in the *requestHydraLabTest* Gradle task input.  When it is passed as true, the *deviceIdentifier* passed in the task is blocked as follows:

- If the **deviceeIdentifier corresponds to a device group**, then it blocks any one of the available online unblocked devices from the device group and the test runs on that device.
- If the **deviceIdentifier corresponds to a specific device**, then it blocks that specific device and the test runs on that specific device.

<ins>**Output:**</ins>
- Outputs *BlockedDeviceSerialNumber* that can be used in the next task and used for further task runs on the same device or any further actions.
- Outputs *UnblockDeviceSecretKey* that can be used in the next task in which you want to unblock the device usinig this secret key. 

<ins>**Unblocking a device by a task**</ins>
<ins>**Input:**</ins>
A boolean property *unblockDevice*  and *unblockDeviceSecretKey* needs to be provided in the *requestHydraLabTest* Gradle task input.  When the unblockDevice is passed as true and unblockDeviceSecretKey is not empty , then the *deviceIdentifier* passed in the task is unblocked as follows:

- **The deviceIdentifier should correspond to a specific device and not a group**, if so it then runs task on that device and unblocks that specific device , so that it can be used again by other tasks.

<ins>**Unblocking frozen blocked devices**</ins>
Automatically unblocking of the devices which have been blocked for more than 4 hours. The default time for unblocking a device is taken as 4 hours for now.

<ins>**Usecase**</ins>
This is useful in cases when you want to run multiple tasks on the same device one after the other.

<ins>**typeSpecificParamCheck**</ins>
Added the following type specific param check for runningType <ins>INSTRUMENTATION</ins>:

- Added check that a task should not set both *unblockDevice* and *blockDevice* as true in the same task as this is always true by default and redundant.
- Added check that when *unblockDevice* is set to true the value of *unblockDeviceSecretKey* should not be empty as it is required to unblock a specific device blocked by a specific task.
- Added check that when *unblockDevice* is set to true the value of *deviceIdentifier* passed for blocking should not be a group and instead it should be a specific device serial number.

### Linked GitHub issue ID: #673


## Pull Request Checklist
<!-- Put an x in the boxes that apply. This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Code compiles correctly with all tests are passed.
- [x] I've read the [contributing guide](https://github.com/microsoft/HydraLab/blob/main/CONTRIBUTING.md#making-changes-to-the-code) and followed the recommended practices.
- [ ] [Wikis](https://github.com/microsoft/HydraLab/wiki) or [README](https://github.com/microsoft/HydraLab/blob/main/README.md) have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
*If this introduces a breaking change for Hydra Lab users, please describe the impact and migration path.*

- [ ] Yes
- [x] No

## How you tested it
Tested it on the center side by sending a POST api `api/test/task/run` with required parameters. It successfully blocks and unblocks the device successfully. This can be validated from the test task id as well. Here are the screenshots of the same.

**Blocking:**
<img width="1343" alt="Screenshot 2025-02-27 at 11 49 46" src="https://github.com/user-attachments/assets/582f36fb-5b72-4a73-ba50-79ab24e6b42d" />

**Unblocking:**
<img width="1344" alt="Screenshot 2025-02-27 at 11 52 38" src="https://github.com/user-attachments/assets/72a7b040-dc0e-4455-bdf2-55490f4f2554" />

**Run task on a blocked device again:**
<img width="1320" alt="Screenshot 2025-02-28 at 14 33 54" src="https://github.com/user-attachments/assets/6e9e6b86-94ab-4df0-b0bd-a3d94657660b" />


**Blocking unblocking in the same test task should throw Exception:**
<img width="1318" alt="Screenshot 2025-02-28 at 13 56 35" src="https://github.com/user-attachments/assets/27c26e84-fce8-4f5d-9500-65b8dc0c96ea" />

**Unblocking a device but no/empty secret key passed to unblock the device should throw exception:**
<img width="1312" alt="Screenshot 2025-02-28 at 13 56 14" src="https://github.com/user-attachments/assets/5fc52cb3-9ae2-462f-a12e-8b9206705959" />

**Unblocking a device but deviceIdentifier of a group is passed should throw exception:**
<img width="1322" alt="Screenshot 2025-02-28 at 14 24 36" src="https://github.com/user-attachments/assets/5a0e24f8-da26-492f-bf0a-588d84d14b4a" />




Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Technical design
- [ ] Build related changes
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Code style update (formatting, renaming) or Documentation content changes
- [ ] Other (please describe): 

### Feature UI screenshots or Technical design diagrams
*If this is a relatively large or complex change, kick it off by drawing the tech design with PlantUML and explaining why you chose the solution you did and what alternatives you considered, etc...*
