### PR TITLE
Save Blocked Device Information in BlockedDeviceInfoRepository for persistence and fix formatting error

### DIFF
--- a/center/src/main/java/com/microsoft/hydralab/center/service/DeviceAgentManagementService.java
+++ b/center/src/main/java/com/microsoft/hydralab/center/service/DeviceAgentManagementService.java
@@ -933,13 +933,9 @@ public class DeviceAgentManagementService {
                 continue;
             }
 
-            if (isDeviceBlocked(deviceSerial)) {
-                Assert.isTrue(!isAll, "Some of the devices in the device group are blocked!");
-                continue;
-            }
-
             isAllOffline = false;
-            if (device.isOnline()) {
+
+            if (device.isOnline()&&!isDeviceBlocked(deviceSerial)) {
                 List<String> devices = testAgentDevicesMap.getOrDefault(device.getAgentId(), new ArrayList<>());
                 devices.add(device.getSerialNum());
                 testAgentDevicesMap.put(device.getAgentId(), devices);
@@ -1163,7 +1159,7 @@ public class DeviceAgentManagementService {
             if (blockedDevicesMap.containsKey(deviceIdentifier)){
                 return true;
             }
-            if (blockedDeviceInfoRepository.existsByBlockedDeviceSerialNumber(deviceIdentifier)) {
+            if (blockedDeviceInfoRepository.existsById(deviceIdentifier)) {
                 blockedDevicesMap.put(deviceIdentifier, blockedDeviceInfoRepository.findByBlockedDeviceSerialNumber(deviceIdentifier));
                 return true;
             }
@@ -1177,7 +1173,7 @@ public class DeviceAgentManagementService {
             synchronized (blockedDevicesMap) {
                 for (String deviceSerial : deviceSerials) {
                     if (!blockedDevicesMap.containsKey(deviceSerial)) {
-                        if (blockedDeviceInfoRepository.existsByBlockedDeviceSerialNumber(deviceIdentifier)) {
+                        if (blockedDeviceInfoRepository.existsById(deviceIdentifier)) {
                             blockedDevicesMap.put(deviceIdentifier, blockedDeviceInfoRepository.findByBlockedDeviceSerialNumber(deviceIdentifier));
                             continue;
                         }
@@ -1197,8 +1193,8 @@ public class DeviceAgentManagementService {
                 BlockedDeviceInfo blockedDeviceInfo = blockedDevicesMap.get(testTaskSpec.deviceIdentifier);
                 if (blockedDeviceInfo.getBlockingTaskUUID().equals(testTaskSpec.unblockDeviceSecretKey)) {
                     blockedDevicesMap.remove(testTaskSpec.deviceIdentifier);
-                    if (blockedDeviceInfoRepository.existsByBlockedDeviceSerialNumber(testTaskSpec.deviceIdentifier)) {
-                        blockedDeviceInfoRepository.deleteByBlockedDeviceSerialNumber(testTaskSpec.deviceIdentifier);
+                    if (blockedDeviceInfoRepository.existsById(testTaskSpec.deviceIdentifier)) {
+                        blockedDeviceInfoRepository.deleteById(testTaskSpec.deviceIdentifier);
                     }
                     testTaskSpec.unblockedDeviceSerialNumber = testTaskSpec.deviceIdentifier;
 
@@ -1206,8 +1202,8 @@ public class DeviceAgentManagementService {
                     throw new IllegalArgumentException("Invalid unblock device secret key!");
                 }
             } else {
-                if (blockedDeviceInfoRepository.existsByBlockedDeviceSerialNumber(testTaskSpec.deviceIdentifier)) {
-                    blockedDeviceInfoRepository.deleteByBlockedDeviceSerialNumber(testTaskSpec.deviceIdentifier);
+                if (blockedDeviceInfoRepository.existsById(testTaskSpec.deviceIdentifier)) {
+                    blockedDeviceInfoRepository.deleteById(testTaskSpec.deviceIdentifier);
                 }
                 log.warn("Device {} is already unblocked.", testTaskSpec.deviceIdentifier);
                 testTaskSpec.unblockedDeviceSerialNumber = testTaskSpec.deviceIdentifier;
@@ -1232,8 +1228,8 @@ public class DeviceAgentManagementService {
                 if (durationBlocked.compareTo(Const.DeviceGroup.BLOCKED_DEVICE_TIMEOUT) > 0) {
                     log.info("Unblocking device {} since it has been blocked for more than {} hours.", entry.getKey(), durationBlocked);
                     iterator.remove();
-                    if (blockedDeviceInfoRepository.existsByBlockedDeviceSerialNumber(blockedDeviceSerialNumber)) {
-                        blockedDeviceInfoRepository.deleteByBlockedDeviceSerialNumber(blockedDeviceSerialNumber);
+                    if (blockedDeviceInfoRepository.existsById(blockedDeviceSerialNumber)) {
+                        blockedDeviceInfoRepository.deleteById(blockedDeviceSerialNumber);
                     }
                 }
             }
@@ -1259,7 +1255,7 @@ public class DeviceAgentManagementService {
             BlockedDeviceInfo blockedDeviceInfo = blockedDevicesMap.get(testTaskSpec.deviceIdentifier);
 
             if (blockedDeviceInfo == null) {
-                if (blockedDeviceInfoRepository.existsByBlockedDeviceSerialNumber(testTaskSpec.deviceIdentifier)){
+                if (blockedDeviceInfoRepository.existsById(testTaskSpec.deviceIdentifier)){
                     blockedDeviceInfo = blockedDeviceInfoRepository.findByBlockedDeviceSerialNumber(testTaskSpec.deviceIdentifier);
                     blockedDevicesMap.put(testTaskSpec.deviceIdentifier, blockedDeviceInfo);
                     return blockedDeviceInfo.getBlockingTaskUUID().equals(testTaskSpec.unblockDeviceSecretKey);

--- a/common/src/main/java/com/microsoft/hydralab/common/entity/common/BlockedDeviceInfo.java
+++ b/common/src/main/java/com/microsoft/hydralab/common/entity/common/BlockedDeviceInfo.java
@@ -6,13 +6,21 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
 
+import javax.persistence.*;
+import java.io.Serializable;
 import java.time.Instant;
 
 @Getter
 @Setter
 @ToString
-public class BlockedDeviceInfo {
-    public Instant blockedTime;
-    public String blockingTaskUUID;
+@Entity
+@Table
+public class BlockedDeviceInfo implements Serializable {
+    @Id
+    @Column(name = "blocked_device_serial_number", nullable = false)
     public String blockedDeviceSerialNumber;
+    @Column(name = "blocked_time", nullable = false)
+    public Instant blockedTime;
+    @Column(name = "blocking_task_uuid", nullable = false)
+    public String blockingTaskUUID;
 }

--- a/common/src/main/java/com/microsoft/hydralab/common/repository/BlockedDeviceInfoRepository.java
+++ b/common/src/main/java/com/microsoft/hydralab/common/repository/BlockedDeviceInfoRepository.java
@@ -3,15 +3,29 @@ package com.microsoft.hydralab.common.repository;
 import com.microsoft.hydralab.common.entity.common.BlockedDeviceInfo;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import javax.transaction.Transactional;
+import java.time.Instant;
 import java.util.List;
 
 @Repository
 public interface BlockedDeviceInfoRepository extends JpaRepository<BlockedDeviceInfo, String>, JpaSpecificationExecutor<BlockedDeviceInfo> {
+    @Transactional
     BlockedDeviceInfo findByBlockedDeviceSerialNumber(String blockedDeviceSerialNumber);
 
+    @Transactional
     boolean existsByBlockedDeviceSerialNumber(String blockedDeviceSerialNumber);
 
+    @Modifying
+    @Transactional
     void deleteByBlockedDeviceSerialNumber(String blockedDeviceSerialNumber);
+
+    @Modifying
+    @Transactional
+    @Query("DELETE FROM BlockedDeviceInfo b WHERE b.blockedTime < :time")
+    void deleteByBlockedTimeBefore(@Param("time") Instant time);
 }

--- a/common/src/main/java/com/microsoft/hydralab/common/repository/BlockedDeviceInfoRepository.java
+++ b/common/src/main/java/com/microsoft/hydralab/common/repository/BlockedDeviceInfoRepository.java
@@ -1,0 +1,17 @@
+package com.microsoft.hydralab.common.repository;
+
+import com.microsoft.hydralab.common.entity.common.BlockedDeviceInfo;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface BlockedDeviceInfoRepository extends JpaRepository<BlockedDeviceInfo, String>, JpaSpecificationExecutor<BlockedDeviceInfo> {
+    BlockedDeviceInfo findByBlockedDeviceSerialNumber(String blockedDeviceSerialNumber);
+
+    boolean existsByBlockedDeviceSerialNumber(String blockedDeviceSerialNumber);
+
+    void deleteByBlockedDeviceSerialNumber(String blockedDeviceSerialNumber);
+}

--- a/gradle_plugin/src/main/groovy/com/microsoft/hydralab/utils/HydraLabClientUtils.java
+++ b/gradle_plugin/src/main/groovy/com/microsoft/hydralab/utils/HydraLabClientUtils.java
@@ -231,7 +231,7 @@ public class HydraLabClientUtils {
         }
 
         if (testConfig.unblockDevice && testConfig.deviceConfig.deviceIdentifier.equals(runningTest.unblockedDeviceSerialNumber)) {
-            printlnf("##[section] Device % s, unblocked.", runningTest.unblockedDeviceSerialNumber);
+            printlnf("##[section] Device %s, unblocked.", runningTest.unblockedDeviceSerialNumber);
         }
 
         String testReportUrl = apiConfig.getTestReportUrl(runningTest.id);


### PR DESCRIPTION
<!-- Please provide brief information about the PR, what it contains & its purpose, new behaviors after the change. And let us know here if you need any help: https://github.com/microsoft/HydraLab/issues/new -->

## Description
The PR aims to save the blocked Device Information in a BlockedDeviceInfoRepository Database to persist it across sessions even if the center gets restarted or the connection between the agent and server is lost due to network problems. 

<!-- A few words to explain your changes -->

- `common/src/main/java/com/microsoft/hydralab/common/repository/BlockedDeviceInfoRepository.java`: Added Repository to save blocked device information in the database.
- `gradle_plugin/src/main/groovy/com/microsoft/hydralab/utils/HydraLabClientUtils.java`: Fixed syntax error / formatting issue.
- `common/src/main/java/com/microsoft/hydralab/common/entity/common/BlockedDeviceInfo.java`: Made it an Entity and added table annotations with primary key to store the blockedDeviceInfo in the Database.
- `center/src/main/java/com/microsoft/hydralab/center/service/DeviceAgentManagementService.java`: Added logic to save the blocked device in the database and as well remove it while unblocking.


### Linked GitHub issue ID: #  

## Pull Request Checklist
<!-- Put an x in the boxes that apply. This is simply a reminder of what we are going to look for before merging your code. -->

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Code compiles correctly with all tests are passed.
- [x] I've read the [contributing guide](https://github.com/microsoft/HydraLab/blob/main/CONTRIBUTING.md#making-changes-to-the-code) and followed the recommended practices.
- [ ] [Wikis](https://github.com/microsoft/HydraLab/wiki) or [README](https://github.com/microsoft/HydraLab/blob/main/README.md) have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
*If this introduces a breaking change for Hydra Lab users, please describe the impact and migration path.*

- [ ] Yes
- [x] No

## How you tested it
*Please make sure the change is tested, you can test it by adding UTs, do local test and share the screenshots, etc.*
**Blocking of a device**
<img width="1358" alt="Screenshot 2025-03-11 at 10 10 15" src="https://github.com/user-attachments/assets/899be4f1-300c-4cef-933d-a6ca2128ec71" />

**Unblocking of a device**
<img width="1336" alt="Screenshot 2025-03-11 at 10 36 26" src="https://github.com/user-attachments/assets/6bcaa078-ee04-4689-9696-0124c9278885" />
<img width="1336" alt="Screenshot 2025-03-11 at 10 36 26" src="https://github.com/user-attachments/assets/c63c752f-b948-45f1-beb5-a9a2d68dfb73" />

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Technical design
- [ ] Build related changes
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Code style update (formatting, renaming) or Documentation content changes
- [ ] Other (please describe): 

### Feature UI screenshots or Technical design diagrams
*If this is a relatively large or complex change, kick it off by drawing the tech design with PlantUML and explaining why you chose the solution you did and what alternatives you considered, etc...*
