### PR TITLE
Bugfix: If unblock failed and all devices in a group were blocked, task would be added to queue and waiting for cron to unblock

### DIFF
--- a/center/src/main/java/com/microsoft/hydralab/center/controller/TestTaskController.java
+++ b/center/src/main/java/com/microsoft/hydralab/center/controller/TestTaskController.java
@@ -99,6 +99,8 @@ public class TestTaskController {
                 }
                 testTaskService.checkTestTaskTeamConsistency(testTaskSpec);
             }
+            // unblock frozen devices
+            deviceAgentManagementService.unblockFrozenBlockedDevices();
             //if the queue is not empty, the task will be added to the queue directly
             if (testTaskService.isQueueEmpty()
                     || Task.RunnerType.APK_SCANNER.name().equals(testTaskSpec.runningType)

--- a/center/src/main/java/com/microsoft/hydralab/center/service/DeviceAgentManagementService.java
+++ b/center/src/main/java/com/microsoft/hydralab/center/service/DeviceAgentManagementService.java
@@ -707,7 +707,6 @@ public class DeviceAgentManagementService {
 
     public JSONObject runTestTaskBySpec(TestTaskSpec testTaskSpec) {
         JSONObject result;
-        unblockFrozenBlockedDevices();
         if (Task.RunnerType.APPIUM_CROSS.name().equals(testTaskSpec.runningType)) {
             result = runAppiumTestTask(testTaskSpec);
         } else if (Task.RunnerType.T2C_JSON.name().equals(testTaskSpec.runningType)) {

--- a/center/src/main/java/com/microsoft/hydralab/center/service/TestTaskService.java
+++ b/center/src/main/java/com/microsoft/hydralab/center/service/TestTaskService.java
@@ -101,6 +101,8 @@ public class TestTaskService {
         }
         isRunning.set(true);
 
+        // unblock frozen devices
+        deviceAgentManagementService.unblockFrozenBlockedDevices();
         synchronized (taskQueue) {
             Iterator<TestTaskSpec> queueIterator = taskQueue.iterator();
             while (queueIterator.hasNext()) {


### PR DESCRIPTION
…sk would be added to queue and wait corn to unblock

<!-- Please provide brief information about the PR, what it contains & its purpose, new behaviors after the change. And let us know here if you need any help: https://github.com/microsoft/HydraLab/issues/new -->

## Description

<!-- A few words to explain your changes -->

### Linked GitHub issue ID: #  

## Pull Request Checklist
<!-- Put an x in the boxes that apply. This is simply a reminder of what we are going to look for before merging your code. -->

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Code compiles correctly with all tests are passed.
- [x] I've read the [contributing guide](https://github.com/microsoft/HydraLab/blob/main/CONTRIBUTING.md#making-changes-to-the-code) and followed the recommended practices.
- [ ] [Wikis](https://github.com/microsoft/HydraLab/wiki) or [README](https://github.com/microsoft/HydraLab/blob/main/README.md) have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
*If this introduces a breaking change for Hydra Lab users, please describe the impact and migration path.*

- [x] Yes
- [ ] No

## How you tested it
*Please make sure the change is tested, you can test it by adding UTs, do local test and share the screenshots, etc.*


Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Technical design
- [ ] Build related changes
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Code style update (formatting, renaming) or Documentation content changes
- [ ] Other (please describe): 

### Feature UI screenshots or Technical design diagrams
*If this is a relatively large or complex change, kick it off by drawing the tech design with PlantUML and explaining why you chose the solution you did and what alternatives you considered, etc...*
