### PR TITLE
Update images to use jaz

### DIFF
--- a/agent/Dockerfile
+++ b/agent/Dockerfile
@@ -35,4 +35,4 @@ COPY ${JAR_FILE} /app.jar
 # Official doc about connecting package with repo: https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#labelling-container-images
 LABEL org.opencontainers.image.source=https://github.com/microsoft/HydraLab
 
-ENTRYPOINT ["java","-jar","/app.jar","--spring.profiles.active=docker"]
+ENTRYPOINT ["jaz","-jar","/app.jar","--spring.profiles.active=docker"]

--- a/center/deploy_startup/start.sh
+++ b/center/deploy_startup/start.sh
@@ -17,4 +17,4 @@ if ${CLAMAV_ENABLED}; then
 fi
 
 cd /
-java -jar /app.jar --spring.profiles.active=${CENTER_APP_PROFILE}
+jaz -jar /app.jar --spring.profiles.active=${CENTER_APP_PROFILE}


### PR DESCRIPTION
jaz is the Azure Command Launcher for Java and it will auto tune the JVM based on resources available and JDK version used.

To learn more: https://aka.ms/jaz
